### PR TITLE
Fix message property fidelity, session state error handling, and management link robustness

### DIFF
--- a/src/AzureServiceBusEmulator.Core/Amqp/EmulatorContainer.cs
+++ b/src/AzureServiceBusEmulator.Core/Amqp/EmulatorContainer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using global::Amqp;
@@ -293,12 +294,17 @@ public class EmulatorContainer : IContainer
                 });
                 return;
             }
-            var replyTo = target.Address;
+            // The reply-to address identifies the response link for request correlation.
+            // Microsoft.Azure.Amqp sets Target.Address to a GUID used as ReplyTo in requests.
+            // Fall back to the link name if Target.Address is unexpectedly null.
+            var replyTo = target.Address ?? link.Name;
 
             lock (entry.ResponseLinks)
             {
                 entry.ResponseLinks[replyTo] = link;
             }
+
+            Log.LogInformation("AttachRequestProcessorLink: response link for '{Address}', replyTo='{ReplyTo}'", address, replyTo);
 
             // SettleOnSend has an internal setter — use reflection.
             SettleOnSendProperty?.SetValue(link, true);
@@ -385,7 +391,23 @@ public class EmulatorContainer : IContainer
 
         if (responseLink == null)
         {
+            // Fallback: if ReplyTo didn't match but there's exactly one response link,
+            // use it. This handles cases where the SDK's ReplyTo format doesn't match
+            // the Target.Address stored during link attachment.
+            lock (entry.ResponseLinks)
+            {
+                if (entry.ResponseLinks.Count == 1)
+                {
+                    responseLink = entry.ResponseLinks.Values.First();
+                    Log.LogInformation("DispatchRequest: using fallback response link (single available)");
+                }
+            }
+        }
+
+        if (responseLink == null)
+        {
             // No response link — reject the message.
+            Log.LogWarning("DispatchRequest: no response link found for ReplyTo={ReplyTo}", message.Properties?.ReplyTo);
             link.DisposeMessage(message, new Rejected
             {
                 Error = new Error(new Symbol("amqp:not-found"))

--- a/src/AzureServiceBusEmulator.Core/Amqp/ManagementLinkEndpoint.cs
+++ b/src/AzureServiceBusEmulator.Core/Amqp/ManagementLinkEndpoint.cs
@@ -304,7 +304,13 @@ public class ManagementLinkEndpoint : IRequestProcessor
         }
 
         var sessionManager = FindSessionManager();
-        var state = sessionManager?.GetSessionState(sessionId);
+        if (sessionManager is null)
+        {
+            SendErrorResponse(requestContext, 400, "Entity does not support sessions");
+            return;
+        }
+
+        var state = sessionManager.GetSessionState(sessionId);
 
         var responseBody = new Map
         {
@@ -352,7 +358,14 @@ public class ManagementLinkEndpoint : IRequestProcessor
             return;
         }
 
-        FindSessionManager()?.SetSessionState(sessionId, state);
+        var sessionManager = FindSessionManager();
+        if (sessionManager is null)
+        {
+            SendErrorResponse(requestContext, 400, "Entity does not support sessions");
+            return;
+        }
+
+        sessionManager.SetSessionState(sessionId, state);
 
         var response = new Message()
         {

--- a/src/AzureServiceBusEmulator.Core/Amqp/ReceiverLinkEndpoint.cs
+++ b/src/AzureServiceBusEmulator.Core/Amqp/ReceiverLinkEndpoint.cs
@@ -187,27 +187,44 @@ public class ReceiverLinkEndpoint : LinkEndpoint
     {
         var lockGuid = Guid.TryParse(brokered.LockToken, out var guid) ? guid : Guid.NewGuid();
 
+        var header = new Header
+        {
+            // AMQP Header.DeliveryCount is 0-based (number of prior unsuccessful
+            // delivery attempts). The Azure SDK adds 1 to get the 1-based
+            // DeliveryCount exposed on ServiceBusReceivedMessage.
+            DeliveryCount = (uint)Math.Max(0, brokered.DeliveryCount - 1)
+        };
+
+        // Preserve TTL on outgoing messages so the SDK can calculate expiry.
+        if (brokered.TimeToLive != TimeSpan.MaxValue && brokered.TimeToLive > TimeSpan.Zero)
+        {
+            header.Ttl = (uint)brokered.TimeToLive.TotalMilliseconds;
+        }
+
+        var properties = new Properties
+        {
+            MessageId = brokered.MessageId,
+            CorrelationId = brokered.CorrelationId,
+            ContentType = brokered.ContentType,
+            Subject = brokered.Subject,
+            ReplyTo = brokered.ReplyTo,
+            To = brokered.To,
+            GroupId = brokered.SessionId,
+            ReplyToGroupId = brokered.ReplyToSessionId,
+            CreationTime = brokered.EnqueuedTimeUtc.UtcDateTime
+        };
+
+        // Set AbsoluteExpiryTime so the Azure SDK can determine message expiry.
+        if (brokered.TimeToLive != TimeSpan.MaxValue && brokered.TimeToLive > TimeSpan.Zero)
+        {
+            properties.AbsoluteExpiryTime = brokered.EnqueuedTimeUtc.Add(brokered.TimeToLive).UtcDateTime;
+        }
+
         var message = new Message()
         {
             BodySection = new Data { Binary = brokered.Body ?? [] },
-            Properties = new Properties
-            {
-                MessageId = brokered.MessageId,
-                CorrelationId = brokered.CorrelationId,
-                ContentType = brokered.ContentType,
-                Subject = brokered.Subject,
-                ReplyTo = brokered.ReplyTo,
-                To = brokered.To,
-                GroupId = brokered.SessionId,
-                ReplyToGroupId = brokered.ReplyToSessionId
-            },
-            Header = new Header
-            {
-                // AMQP Header.DeliveryCount is 0-based (number of prior unsuccessful
-                // delivery attempts). The Azure SDK adds 1 to get the 1-based
-                // DeliveryCount exposed on ServiceBusReceivedMessage.
-                DeliveryCount = (uint)Math.Max(0, brokered.DeliveryCount - 1)
-            },
+            Properties = properties,
+            Header = header,
             MessageAnnotations = new MessageAnnotations
             {
                 [new Symbol("x-opt-sequence-number")] = brokered.SequenceNumber,
@@ -221,6 +238,9 @@ public class ReceiverLinkEndpoint : LinkEndpoint
 
         if (brokered.PartitionKey is not null)
             message.MessageAnnotations[new Symbol("x-opt-partition-key")] = brokered.PartitionKey;
+
+        if (brokered.DeadLetterSource is not null)
+            message.MessageAnnotations[new Symbol("x-opt-dead-letter-source")] = brokered.DeadLetterSource;
 
         if (brokered.ApplicationProperties.Count > 0
             || brokered.DeadLetterReason is not null

--- a/src/AzureServiceBusEmulator.Core/Amqp/SessionReceiverLinkEndpoint.cs
+++ b/src/AzureServiceBusEmulator.Core/Amqp/SessionReceiverLinkEndpoint.cs
@@ -78,8 +78,14 @@ public class SessionReceiverLinkEndpoint : LinkEndpoint
                 {
                     link.SendMessage(amqpMessage);
                 }
-                catch
+                catch (Exception ex)
                 {
+                    // Send failed — link is closing/draining.
+                    // Abandon the message so it re-enters the queue for the next consumer.
+                    Log.LogDebug(ex, "Session PUMP SendMessage failed for session '{SessionId}', abandoning message {MessageId}",
+                        _session.SessionId, brokered.MessageId);
+                    if (brokered.LockToken is not null)
+                        _queue.Abandon(brokered.LockToken);
                     break;
                 }
             }

--- a/src/AzureServiceBusEmulator.Core/Broker/BrokeredMessage.cs
+++ b/src/AzureServiceBusEmulator.Core/Broker/BrokeredMessage.cs
@@ -47,6 +47,8 @@ public sealed class BrokeredMessage
 
     public string? DeadLetterErrorDescription { get; set; }
 
+    public string? DeadLetterSource { get; set; }
+
     public DateTimeOffset EnqueuedTimeUtc { get; set; } = DateTimeOffset.UtcNow;
 
     public string? LockToken { get; set; }

--- a/src/AzureServiceBusEmulator.Core/Broker/QueueEntity.cs
+++ b/src/AzureServiceBusEmulator.Core/Broker/QueueEntity.cs
@@ -289,6 +289,7 @@ public sealed class QueueEntity
     {
         message.DeadLetterReason = reason;
         message.DeadLetterErrorDescription = description;
+        message.DeadLetterSource = Name;
         DeadLetterQueue.Enqueue(message);
     }
 


### PR DESCRIPTION
- Preserve TTL on outgoing AMQP messages (Header.Ttl + Properties.AbsoluteExpiryTime)
- Add Properties.CreationTime to outgoing messages
- Add x-opt-dead-letter-source annotation and DeadLetterSource tracking
- Fix HandleSetSessionState/HandleGetSessionState to return error when session manager is null
- Handle null Target.Address on response links with fallback to link name
- Add fallback response link lookup when ReplyTo doesn't match stored key
- Abandon messages on session pump send failure instead of silently dropping

https://claude.ai/code/session_01V8vE8GKGJmgv8aW9hC8nPV