### PR TITLE
Code cleanup: extract shared utilities, deduplicate, tighten API

### DIFF
--- a/src/AzureServiceBusEmulator.Core/Amqp/ManagementLinkEndpoint.cs
+++ b/src/AzureServiceBusEmulator.Core/Amqp/ManagementLinkEndpoint.cs
@@ -251,15 +251,7 @@ public class ManagementLinkEndpoint : IRequestProcessor
 
     private void HandleRenewSessionLock(RequestContext requestContext)
     {
-        // The Azure SDK sends session-id in the message body map, not in ApplicationProperties
-        string? sessionId = null;
-        if (requestContext.Message.Body is Map renewBody)
-        {
-            if (TryGetMapValue(renewBody, "session-id", out var sidObj))
-                sessionId = sidObj?.ToString();
-        }
-        // Fallback: also check ApplicationProperties for compatibility
-        sessionId ??= requestContext.Message.ApplicationProperties?["session-id"] as string;
+        var sessionId = ExtractSessionId(requestContext);
 
         var sessionManager = FindSessionManager();
         if (sessionId is null || sessionManager is null)
@@ -293,15 +285,7 @@ public class ManagementLinkEndpoint : IRequestProcessor
 
     private void HandleGetSessionState(RequestContext requestContext)
     {
-        // The Azure SDK sends session-id in the message body map, not in ApplicationProperties
-        string? sessionId = null;
-        if (requestContext.Message.Body is Map getBody)
-        {
-            if (TryGetMapValue(getBody, "session-id", out var sidObj))
-                sessionId = sidObj?.ToString();
-        }
-        // Fallback: also check ApplicationProperties for compatibility
-        sessionId ??= requestContext.Message.ApplicationProperties?["session-id"] as string;
+        var sessionId = ExtractSessionId(requestContext);
 
         if (sessionId is null)
         {
@@ -336,15 +320,11 @@ public class ManagementLinkEndpoint : IRequestProcessor
 
     private void HandleSetSessionState(RequestContext requestContext)
     {
-        // The Azure SDK sends session-id in the message body map, not in ApplicationProperties
-        string? sessionId = null;
+        var sessionId = ExtractSessionId(requestContext);
         byte[]? state = null;
 
         if (requestContext.Message.Body is Map setBody)
         {
-            if (TryGetMapValue(setBody, "session-id", out var sidObj))
-                sessionId = sidObj?.ToString();
-
             if (TryGetMapValue(setBody, "session-state", out var stateObj))
             {
                 state = stateObj switch
@@ -387,6 +367,21 @@ public class ManagementLinkEndpoint : IRequestProcessor
 
     /// <summary>
     /// Finds the SessionManager for session operations. Uses the scoped queue if available,
+    /// Extracts a session ID from a management request message body or application properties.
+    /// </summary>
+    private static string? ExtractSessionId(RequestContext requestContext)
+    {
+        string? sessionId = null;
+        if (requestContext.Message.Body is Map body)
+        {
+            if (TryGetMapValue(body, "session-id", out var sidObj))
+                sessionId = sidObj?.ToString();
+        }
+        sessionId ??= requestContext.Message.ApplicationProperties?["session-id"] as string;
+        return sessionId;
+    }
+
+    /// <summary>
     /// otherwise searches all queues in the namespace.
     /// </summary>
     private SessionManager? FindSessionManager()

--- a/src/AzureServiceBusEmulator.Core/Amqp/SenderLinkEndpoint.cs
+++ b/src/AzureServiceBusEmulator.Core/Amqp/SenderLinkEndpoint.cs
@@ -188,7 +188,7 @@ public class SenderLinkEndpoint : LinkEndpoint
     /// Routes a brokered message to the appropriate queue or topic.
     /// Exposed as public for testing.
     /// </summary>
-    public void RouteMessage(string address, BrokeredMessage message)
+    internal void RouteMessage(string address, BrokeredMessage message)
     {
         message.SequenceNumber = _context.NextSequenceNumber();
         message.EnqueuedTimeUtc = DateTimeOffset.UtcNow;

--- a/src/AzureServiceBusEmulator.Core/AzureServiceBusEmulator.Core.csproj
+++ b/src/AzureServiceBusEmulator.Core/AzureServiceBusEmulator.Core.csproj
@@ -10,4 +10,7 @@
   <ItemGroup>
     <PackageReference Include="AMQPNetLite" Version="2.5.1" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="AzureServiceBusEmulator.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/AzureServiceBusEmulator.Core/Hosting/EmulatorInfrastructure.cs
+++ b/src/AzureServiceBusEmulator.Core/Hosting/EmulatorInfrastructure.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
+
+namespace AzureServiceBusEmulator.Core.Hosting;
+
+/// <summary>
+/// Shared infrastructure utilities used by both the standalone host and the test fixture.
+/// </summary>
+public static class EmulatorInfrastructure
+{
+    /// <summary>
+    /// Finds an available TCP port on the loopback interface.
+    /// </summary>
+    public static int GetFreePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    /// <summary>
+    /// Loads the ASP.NET Core HTTPS development certificate from the current user's certificate store.
+    /// Throws if no dev cert is found.
+    /// </summary>
+    public static X509Certificate2 LoadDevCert()
+    {
+        using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+        store.Open(OpenFlags.ReadOnly);
+        // OID 1.3.6.1.4.1.311.84.1.1 identifies ASP.NET Core dev certs
+        var certs = store.Certificates.Find(
+            X509FindType.FindByExtension, "1.3.6.1.4.1.311.84.1.1", validOnly: false);
+        if (certs.Count == 0)
+            throw new InvalidOperationException(
+                "ASP.NET HTTPS development certificate not found. " +
+                "Run 'dotnet dev-certs https --trust' to generate and trust the certificate.");
+        return new X509Certificate2(certs[0]);
+    }
+
+    /// <summary>
+    /// On Linux, ensures the ASP.NET dev cert is in SSL_CERT_DIR so the Azure SDK's
+    /// AMQP TLS client trusts it. dotnet dev-certs --trust places the cert in
+    /// ~/.aspnet/dev-certs/trust but doesn't update SSL_CERT_DIR automatically.
+    /// </summary>
+    public static void EnsureDevCertTrusted()
+    {
+        var trustDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".aspnet", "dev-certs", "trust");
+
+        if (!Directory.Exists(trustDir))
+            return;
+
+        var current = Environment.GetEnvironmentVariable("SSL_CERT_DIR") ?? "";
+        if (!current.Contains(trustDir))
+        {
+            var systemCerts = "/usr/lib/ssl/certs";
+            var newValue = string.IsNullOrEmpty(current)
+                ? $"{trustDir}:{systemCerts}"
+                : $"{trustDir}:{current}";
+            Environment.SetEnvironmentVariable("SSL_CERT_DIR", newValue);
+        }
+    }
+}

--- a/src/AzureServiceBusEmulator.Host/Program.cs
+++ b/src/AzureServiceBusEmulator.Host/Program.cs
@@ -3,9 +3,6 @@ using AzureServiceBusEmulator.Core.Broker;
 using AzureServiceBusEmulator.Core.Dashboard;
 using AzureServiceBusEmulator.Core.Hosting;
 using AzureServiceBusEmulator.Core.Management;
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
-using System.Net.Sockets;
 using Vite.AspNetCore;
 
 // ── Management API server (internal, behind TLS multiplexer) ──
@@ -21,8 +18,8 @@ AmqpLog.Factory = LoggerFactory.Create(b => b
 var publicPort = mgmtBuilder.Configuration.GetValue("Port", 5672);
 var dashboardPort = mgmtBuilder.Configuration.GetValue("DashboardPort", 15672);
 var amqpsPort = 5671;
-var internalHttpPort = GetFreePort();
-var internalAmqpPort = GetFreePort();
+var internalHttpPort = EmulatorInfrastructure.GetFreePort();
+var internalAmqpPort = EmulatorInfrastructure.GetFreePort();
 
 var eventBus = new MessageEventBus();
 var registry = new NamespaceRegistry(eventBus);
@@ -80,7 +77,7 @@ amqpServer.Start();
 
 // ── TLS multiplexers ──
 
-var cert = LoadDevCert();
+var cert = EmulatorInfrastructure.LoadDevCert();
 var multiplexerCts = new CancellationTokenSource();
 
 var multiplexer = new TcpMultiplexer(publicPort, internalAmqpPort, internalHttpPort, cert);
@@ -135,24 +132,3 @@ await Task.WhenAll(
     dashApp.StopAsync(timeout.Token)
 );
 
-static X509Certificate2 LoadDevCert()
-{
-    using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
-    store.Open(OpenFlags.ReadOnly);
-    var certs = store.Certificates.Find(
-        X509FindType.FindByExtension, "1.3.6.1.4.1.311.84.1.1", validOnly: false);
-    if (certs.Count == 0)
-        throw new InvalidOperationException(
-            "ASP.NET HTTPS development certificate not found. " +
-            "Run 'dotnet dev-certs https --trust' to generate and trust the certificate.");
-    return new X509Certificate2(certs[0]);
-}
-
-static int GetFreePort()
-{
-    var listener = new TcpListener(IPAddress.Loopback, 0);
-    listener.Start();
-    var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-    listener.Stop();
-    return port;
-}

--- a/src/AzureServiceBusEmulator.TestHost/ServiceBusEmulatorFixture.cs
+++ b/src/AzureServiceBusEmulator.TestHost/ServiceBusEmulatorFixture.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography.X509Certificates;
 using AzureServiceBusEmulator.Core.Amqp;
 using AzureServiceBusEmulator.Core.Broker;
 using AzureServiceBusEmulator.Core.Dashboard;
@@ -40,11 +39,11 @@ public class ServiceBusEmulatorFixture : IAsyncDisposable
 
     public async Task StartAsync()
     {
-        EnsureDevCertTrusted();
+        EmulatorInfrastructure.EnsureDevCertTrusted();
 
-        PublicPort = GetFreePort();
-        AmqpPort = GetFreePort();
-        HttpPort = GetFreePort();
+        PublicPort = EmulatorInfrastructure.GetFreePort();
+        AmqpPort = EmulatorInfrastructure.GetFreePort();
+        HttpPort = EmulatorInfrastructure.GetFreePort();
 
         // 1. Start Kestrel with plain HTTP on internal port
         var builder = WebApplication.CreateBuilder();
@@ -68,8 +67,8 @@ public class ServiceBusEmulatorFixture : IAsyncDisposable
         _amqpServer = new AmqpServer(new AmqpServerOptions { Port = AmqpPort }, _registry, _scheduledProcessor);
         _amqpServer.Start();
 
-        // 3. Start multiplexer on public port with TLS termination
-        var cert = LoadDevCert();
+        // 4. Start multiplexer on public port with TLS termination
+        var cert = EmulatorInfrastructure.LoadDevCert();
         _multiplexerCts = new CancellationTokenSource();
         _multiplexer = new TcpMultiplexer(PublicPort, AmqpPort, HttpPort, cert);
         _ = _multiplexer.StartAsync(_multiplexerCts.Token);
@@ -97,52 +96,4 @@ public class ServiceBusEmulatorFixture : IAsyncDisposable
     public NamespaceContext GetNamespaceContext() => _registry.GetOrCreate(_namespace);
 
     public NamespaceContext GetDefaultNamespaceContext() => _registry.GetOrCreate("default");
-
-    public static X509Certificate2 LoadDevCert()
-    {
-        using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
-        store.Open(OpenFlags.ReadOnly);
-        // OID 1.3.6.1.4.1.311.84.1.1 identifies ASP.NET Core dev certs
-        var certs = store.Certificates.Find(
-            X509FindType.FindByExtension, "1.3.6.1.4.1.311.84.1.1", validOnly: false);
-        if (certs.Count == 0)
-            throw new InvalidOperationException(
-                "ASP.NET HTTPS development certificate not found. " +
-                "Run 'dotnet dev-certs https --trust' to generate and trust the certificate.");
-        return new X509Certificate2(certs[0]);
-    }
-
-    /// <summary>
-    /// On Linux, the ASP.NET dev cert must be in SSL_CERT_DIR for the Azure SDK's
-    /// AMQP TLS client to trust it. dotnet dev-certs --trust places the cert in
-    /// ~/.aspnet/dev-certs/trust but doesn't update SSL_CERT_DIR automatically.
-    /// </summary>
-    private static void EnsureDevCertTrusted()
-    {
-        var trustDir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".aspnet", "dev-certs", "trust");
-
-        if (!Directory.Exists(trustDir))
-            return;
-
-        var current = Environment.GetEnvironmentVariable("SSL_CERT_DIR") ?? "";
-        if (!current.Contains(trustDir))
-        {
-            var systemCerts = "/usr/lib/ssl/certs";
-            var newValue = string.IsNullOrEmpty(current)
-                ? $"{trustDir}:{systemCerts}"
-                : $"{trustDir}:{current}";
-            Environment.SetEnvironmentVariable("SSL_CERT_DIR", newValue);
-        }
-    }
-
-    private static int GetFreePort()
-    {
-        var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
 }

--- a/tests/AzureServiceBusEmulator.Tests/Hosting/TcpMultiplexerTests.cs
+++ b/tests/AzureServiceBusEmulator.Tests/Hosting/TcpMultiplexerTests.cs
@@ -120,7 +120,7 @@ public class TcpMultiplexerTests : IAsyncDisposable
 
         try
         {
-            var cert = ServiceBusEmulatorFixture.LoadDevCert();
+            var cert = EmulatorInfrastructure.LoadDevCert();
             var multiplexer = new TcpMultiplexer(publicPort, amqpPort, httpPort, cert);
             _ = multiplexer.StartAsync(_cts.Token);
 


### PR DESCRIPTION
## Summary

Code cleanup based on a full codebase review. Net -9 lines.

## Changes

### 1. Extract `EmulatorInfrastructure` shared utility
`LoadDevCert()`, `GetFreePort()`, and `EnsureDevCertTrusted()` were duplicated between `Program.cs` (Host) and `ServiceBusEmulatorFixture.cs` (TestHost). Extracted to `Core/Hosting/EmulatorInfrastructure.cs` and replaced all call sites.

### 2. Extract `ExtractSessionId` helper
The session ID extraction pattern (read from request body Map, fallback to ApplicationProperties) was copy-pasted across `HandleRenewSessionLock`, `HandleGetSessionState`, and `HandleSetSessionState` in `ManagementLinkEndpoint`. Extracted to a single helper method.

### 3. Tighten API surface
- `SenderLinkEndpoint.RouteMessage` → `internal` (only used within the assembly)
- Added `InternalsVisibleTo` for the test project

## Not addressed (intentionally)
- Empty catch blocks in message pumps — these are intentional fire-and-forget patterns for link closure/draining
- Magic numbers for timeouts/ports — would add complexity without clear benefit for this codebase size
- Test HTTP handler duplication — lower priority, tests are readable as-is

## Test plan
- [x] 208/208 internal tests pass

https://claude.ai/code/session_01K5NA93wMWKqraiYeKQBo2q