### PR TITLE
Fix silent lock-expiry allowing duplicate delivery (R-DUPE)

### DIFF
--- a/src/AlmostServiceBus.Core/Amqp/ReceiverLinkEndpoint.cs
+++ b/src/AlmostServiceBus.Core/Amqp/ReceiverLinkEndpoint.cs
@@ -134,14 +134,19 @@ public class ReceiverLinkEndpoint : LinkEndpoint
         }
         catch (MessageLockLostException)
         {
-            // The message lock has expired. The message has been re-enqueued for redelivery.
-            // Ideally we'd send a Rejected disposition with com.microsoft:message-lock-lost,
-            // but AMQPNetLite's DispositionContext.Complete(Error) detaches the link entirely.
-            // Instead, we just accept the disposition — the message is already re-enqueued
-            // and will be redelivered. The client won't get a lock-lost error, but will
-            // see the message again with an incremented DeliveryCount.
+            // The message lock has expired and the message has been re-enqueued.
+            // Send a Rejected disposition with com.microsoft:message-lock-lost so
+            // the Azure SDK raises ServiceBusException(Reason=MessageLockLost).
+            // We use Link.DisposeMessage instead of dispositionContext.Complete(Error)
+            // because the latter detaches the entire link.
             Log.LogDebug("DISP lock={LockToken} LOCK EXPIRED (re-enqueued) queue='{Queue}'", lockToken, _queue.Name);
-            dispositionContext.Complete();
+            dispositionContext.Link.DisposeMessage(dispositionContext.Message, new Rejected
+            {
+                Error = new Error(new Symbol("com.microsoft:message-lock-lost"))
+                {
+                    Description = "The lock supplied is invalid. Either the lock expired, or the message has already been removed from the queue."
+                }
+            }, true);
         }
     }
 

--- a/src/AlmostServiceBus.Core/Amqp/SessionReceiverLinkEndpoint.cs
+++ b/src/AlmostServiceBus.Core/Amqp/SessionReceiverLinkEndpoint.cs
@@ -102,34 +102,48 @@ public class SessionReceiverLinkEndpoint : LinkEndpoint
     {
         var lockToken = ReceiverLinkEndpoint.GetLockTokenStatic(dispositionContext.Message);
 
-        if (lockToken is not null && dispositionContext.DeliveryState is not null)
+        try
         {
-            switch (dispositionContext.DeliveryState)
+            if (lockToken is not null && dispositionContext.DeliveryState is not null)
             {
-                case Accepted:
-                    _queue.Complete(lockToken);
-                    break;
-                case Released:
-                    _queue.Abandon(lockToken);
-                    break;
-                case Rejected rejected:
-                    _queue.DeadLetter(lockToken,
-                        rejected.Error?.Condition?.ToString(),
-                        rejected.Error?.Description);
-                    break;
-                case Modified modified:
-                    if (modified.UndeliverableHere == true)
-                        _queue.DeadLetter(lockToken, "Undeliverable", "Message marked as undeliverable.");
-                    else
+                switch (dispositionContext.DeliveryState)
+                {
+                    case Accepted:
+                        _queue.Complete(lockToken);
+                        break;
+                    case Released:
                         _queue.Abandon(lockToken);
-                    break;
-                default:
-                    _queue.Complete(lockToken);
-                    break;
+                        break;
+                    case Rejected rejected:
+                        _queue.DeadLetter(lockToken,
+                            rejected.Error?.Condition?.ToString(),
+                            rejected.Error?.Description);
+                        break;
+                    case Modified modified:
+                        if (modified.UndeliverableHere == true)
+                            _queue.DeadLetter(lockToken, "Undeliverable", "Message marked as undeliverable.");
+                        else
+                            _queue.Abandon(lockToken);
+                        break;
+                    default:
+                        _queue.Complete(lockToken);
+                        break;
+                }
             }
-        }
 
-        dispositionContext.Complete();
+            dispositionContext.Complete();
+        }
+        catch (MessageLockLostException)
+        {
+            Log.LogDebug("DISP lock={LockToken} LOCK EXPIRED (re-enqueued) queue='{Queue}'", lockToken, _queue.Name);
+            dispositionContext.Link.DisposeMessage(dispositionContext.Message, new Rejected
+            {
+                Error = new Error(new Symbol("com.microsoft:message-lock-lost"))
+                {
+                    Description = "The lock supplied is invalid. Either the lock expired, or the message has already been removed from the queue."
+                }
+            }, true);
+        }
     }
 
     public override void OnLinkClosed(ListenerLink link, Error error)

--- a/src/AlmostServiceBus.Core/Broker/QueueEntity.cs
+++ b/src/AlmostServiceBus.Core/Broker/QueueEntity.cs
@@ -20,6 +20,12 @@ public sealed class QueueEntity : IDisposable
     private readonly ConcurrentDictionary<string, BrokeredMessage> _pending = new();
     private readonly ConcurrentDictionary<string, BrokeredMessage> _allMessages = new();
     private readonly ConcurrentDictionary<string, DateTimeOffset> _recentMessageIds = new();
+    /// <summary>
+    /// Lock tokens removed by <see cref="SweepExpiredLocks"/>. When a consumer calls
+    /// <see cref="Complete"/> after the sweep already re-enqueued the message, we need
+    /// to throw <see cref="MessageLockLostException"/> instead of silently returning.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, byte> _sweptLockTokens = new();
     private readonly bool _isDeadLetterQueue;
     private QueueEntity? _deadLetterQueue;
     private SessionManager? _sessionManager;
@@ -306,7 +312,13 @@ public sealed class QueueEntity : IDisposable
     public void Complete(string lockToken)
     {
         if (!_pending.TryRemove(lockToken, out var message))
+        {
+            // If the sweep already re-enqueued this message, the consumer's lock
+            // has expired — signal the error so the client can handle redelivery.
+            if (_sweptLockTokens.TryRemove(lockToken, out _))
+                throw new MessageLockLostException(lockToken);
             return;
+        }
 
         // Enforce lock expiry — if the lock has expired, re-enqueue the message
         // and throw so the AMQP layer can reject the disposition.
@@ -333,7 +345,11 @@ public sealed class QueueEntity : IDisposable
     public void Abandon(string lockToken)
     {
         if (!_pending.TryRemove(lockToken, out var message))
+        {
+            if (_sweptLockTokens.TryRemove(lockToken, out _))
+                throw new MessageLockLostException(lockToken);
             return;
+        }
 
         _eventBus?.Publish(new MessageEvent(
             MessageEventType.Abandoned, _namespaceName ?? "", _entityName ?? "",
@@ -364,7 +380,11 @@ public sealed class QueueEntity : IDisposable
     public void DeadLetter(string lockToken, string? reason, string? description)
     {
         if (!_pending.TryRemove(lockToken, out var message))
+        {
+            if (_sweptLockTokens.TryRemove(lockToken, out _))
+                throw new MessageLockLostException(lockToken);
             return;
+        }
 
         if (_allMessages.TryGetValue(lockToken, out var tracked))
             tracked.State = MessageState.DeadLettered;
@@ -410,6 +430,10 @@ public sealed class QueueEntity : IDisposable
     /// </summary>
     private void ReEnqueueExpired(string oldLockToken, BrokeredMessage message)
     {
+        // Remember this lock token was swept so Complete/Abandon can throw
+        // MessageLockLostException instead of silently returning.
+        _sweptLockTokens[oldLockToken] = 0;
+
         // Remove old dashboard entry — ReEnqueue will create a new one with fresh lock token.
         _allMessages.TryRemove(oldLockToken, out _);
 

--- a/tests/AlmostServiceBus.Tests/Broker/QueueEntityTests.cs
+++ b/tests/AlmostServiceBus.Tests/Broker/QueueEntityTests.cs
@@ -244,6 +244,41 @@ public class QueueEntityTests
     }
 
     [Fact]
+    public void Complete_AfterLockExpirySweep_ThrowsMessageLockLost()
+    {
+        // Bug: when the lock-expiry sweep re-enqueues a message before the consumer
+        // calls Complete(), Complete() silently returns instead of throwing
+        // MessageLockLostException. This causes MassTransit to think the completion
+        // succeeded, while the message has been re-enqueued — leading to R-DUPE.
+        var queue = new QueueEntity("test-queue") { LockDuration = TimeSpan.FromMilliseconds(1) };
+        queue.Enqueue(CreateMessage());
+
+        var msg = queue.TryDequeueImmediate()!;
+        var lockToken = msg.LockToken!;
+
+        // Wait for lock to expire
+        Thread.Sleep(50);
+
+        // Manually trigger the sweep by waiting for the timer (fires every 5s) — too slow.
+        // Instead, simulate the same effect: the message's lock expired and the sweep
+        // removed it from _pending and re-enqueued it. We can trigger this by just waiting
+        // for the background sweep. But with 5s interval that's too slow for a unit test.
+        // Use a shorter approach: set lock duration very short, dequeue, wait, then Complete.
+        // The sweep runs every 5s, so we need to wait for it.
+        // Actually, let's just wait for the sweep to fire.
+        Thread.Sleep(TimeSpan.FromSeconds(6));
+
+        // The sweep should have re-enqueued the message by now.
+        // Complete should throw MessageLockLostException, not silently return.
+        Assert.Throws<MessageLockLostException>(() => queue.Complete(lockToken));
+
+        // Verify the message was re-enqueued (available for redelivery)
+        var redelivered = queue.TryDequeueImmediate();
+        Assert.NotNull(redelivered);
+        Assert.Equal(msg.MessageId, redelivered!.MessageId);
+    }
+
+    [Fact]
     public async Task RenewLock_PreventsExpirySweep_NoDoubleDelivery()
     {
         // Reproduces the race between SweepExpiredLocks and RenewLock:


### PR DESCRIPTION
When the lock-expiry sweep re-enqueued a message, Complete/Abandon/DeadLetter silently returned instead of throwing MessageLockLostException, so clients never learned the lock was lost. Additionally, the AMQP layer was swallowing the exception and sending Accepted back to the client.

Now the broker tracks swept lock tokens and throws on stale settlements, and the AMQP layer sends a proper Rejected disposition with the com.microsoft:message-lock-lost error condition — matching real Azure Service Bus behavior and allowing the Azure SDK to raise ServiceBusException.