### PR TITLE
Claude/fix queue pump stall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,13 +156,12 @@ jobs:
           FILTER="$FILTER&FullyQualifiedName!~tracking_correlation_id_on_everything"
           # Request-reply: named broker reply URI resolution
           FILTER="$FILTER&FullyQualifiedName!~correct_scheme_on_reply_uri"
-          # Request-reply: can_request_reply flakes in CI (passes locally with and without
-          # the parallel-tests patch, including full 93-test Compliance parallel run).
-          # The emulator delivers the response correctly but Wolverine's RemoteInvokeAsync
-          # times out on slower CI runners before the reply queue processor picks it up.
-          FILTER="$FILTER&FullyQualifiedName!~InlineSendingAndReceivingCompliance.can_request_reply"
-          FILTER="$FILTER&FullyQualifiedName!~PrefixedSendingAndReceivingCompliance.can_request_reply"
-          FILTER="$FILTER&FullyQualifiedName!~TopicAndSubscriptionWithCustomRuleSendingAndReceivingCompliance.can_request_reply"
+          # NOTE: can_request_reply and can_send_and_wait were previously excluded here
+          # because Wolverine's default RemoteInvocationTimeout (5s) times out on slower
+          # CI runners before the reply-queue processor picks up the handler's ack.
+          # The remote-invocation-timeout.patch raises DefaultRemoteInvocationTimeout to
+          # 60s in the Inline / Prefixed / TopicAndSubscriptionWithCustomRule sender
+          # fixtures, so both tests now pass in CI and no filter is needed.
           # Inline requeue/DLQ: Wolverine's InlineAzureServiceBusListener._defer completes
           # the AMQP message then re-sends to the retry queue via BatchedSender, but the
           # retry queue never re-delivers.

--- a/patches/wolverine/remote-invocation-timeout.patch
+++ b/patches/wolverine/remote-invocation-timeout.patch
@@ -1,0 +1,39 @@
+diff --git a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/InlineSendingAndReceivingCompliance.cs b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/InlineSendingAndReceivingCompliance.cs
+--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/InlineSendingAndReceivingCompliance.cs
++++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/InlineSendingAndReceivingCompliance.cs
+@@ -20,6 +20,7 @@ public class InlineComplianceFixture : TransportComplianceFixture, IAsyncLifetim
+         await SenderIs(opts =>
+         {
+             opts.UseAzureServiceBusTesting(out _ns);
++            opts.DefaultRemoteInvocationTimeout = 60.Seconds();
+         });
+
+         await ReceiverIs(opts =>
+diff --git a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/sending_compliance_with_prefixes.cs b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/sending_compliance_with_prefixes.cs
+--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/sending_compliance_with_prefixes.cs
++++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/sending_compliance_with_prefixes.cs
+@@ -26,6 +26,7 @@ public class PrefixedComplianceFixture : TransportComplianceFixture, IAsyncLifet
+             opts.UseAzureServiceBusTesting(out _ns)
+                 .PrefixIdentifiers("foo");
+
++            opts.DefaultRemoteInvocationTimeout = 60.Seconds();
+         });
+
+         await ReceiverIs(opts =>
+diff --git a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/send_and_receive_with_topics_and_subscriptions_with_custom_rule.cs b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/send_and_receive_with_topics_and_subscriptions_with_custom_rule.cs
+--- a/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/send_and_receive_with_topics_and_subscriptions_with_custom_rule.cs
++++ b/src/Transports/Azure/Wolverine.AzureServiceBus.Tests/send_and_receive_with_topics_and_subscriptions_with_custom_rule.cs
+@@ -1,4 +1,5 @@
+ using Azure.Messaging.ServiceBus.Administration;
++using JasperFx.Core;
+ using Shouldly;
+ using Wolverine.ComplianceTests.Compliance;
+ using Wolverine.Tracking;
+@@ -17,6 +18,7 @@ public class TopicsWithCustomRuleComplianceFixture()
+         await SenderIs(opts =>
+         {
+             opts.UseAzureServiceBusTesting(out _ns);
++            opts.DefaultRemoteInvocationTimeout = 60.Seconds();
+         });
+
+         await ReceiverIs(opts =>

--- a/src/AlmostServiceBus.Core/Amqp/GuidDeliveryTagHandler.cs
+++ b/src/AlmostServiceBus.Core/Amqp/GuidDeliveryTagHandler.cs
@@ -2,7 +2,6 @@ using System.Reflection;
 using Amqp;
 using Amqp.Framing;
 using Amqp.Handler;
-using Amqp.Listener;
 using Amqp.Types;
 using Microsoft.Extensions.Logging;
 using EventId = Amqp.Handler.EventId;
@@ -40,7 +39,14 @@ public class GuidDeliveryTagHandler : IHandler
     //   DetachPipe=4, DetachSent=5, DetachReceived=6, End=7
     private const int LinkStateStart = 0;
     private const int LinkStateAttachSent = 1;
-    private const int LinkStateAttached = 3;
+    // DetachSent = 5: semantically "we have sent Detach, waiting for response".
+    // When AMQPNetLite's OnDetach runs on a link in this state, it transitions
+    // directly to End WITHOUT sending a Detach response frame. This is crucial
+    // for links whose Attach handshake never completed: the client may have
+    // already End'd the whole AMQP session before our Detach response could
+    // arrive, and any frame on an End'd session causes the client to throw
+    // "session channel N cannot be found" and close the connection.
+    private const int LinkStateDetachSent = 5;
 
     static GuidDeliveryTagHandler()
     {
@@ -104,21 +110,25 @@ public class GuidDeliveryTagHandler : IHandler
     }
 
     /// <summary>
-    /// Handles Detach frames (remote or local) arriving for links that are still in
-    /// Start or AttachSent state. This happens when:
+    /// Handles Detach frames (remote or local) for links in pre-Attached states
+    /// (Start, AttachSent). This happens when:
     ///   - A client times out while waiting for a session receiver link's Attach to
     ///     complete (the server is polling for an available session).
     ///   - A connection reset tears down links that haven't completed the AMQP handshake.
     ///
-    /// AMQPNetLite's state machine rejects Detach in Start/AttachSent state with
-    /// AmqpException, killing the entire connection. For Start state, we use
-    /// CompleteAttach(error) to properly register the link in the session's channel
-    /// map and close it gracefully. For AttachSent, the link is already registered
-    /// (SendAttach called Session.AddLink), so we just transition to Attached.
+    /// AMQPNetLite's state machine rejects Detach in these states with AmqpException,
+    /// killing the entire connection.
     ///
-    /// Simply setting state=Attached via reflection (without CompleteAttach) skips
-    /// Session.AddLink registration → the session's channel map is corrupted → under
-    /// load, "session channel N cannot be found" kills the AMQP connection.
+    /// We transition to DetachSent (not Attached). In AMQPNetLite's OnDetach flow:
+    ///   - Attached + receive Detach → DetachReceived → sends Detach response → End
+    ///   - DetachSent + receive Detach → End (no response frame sent)
+    ///
+    /// Sending a response Detach is risky when the client has concurrently End'd the
+    /// whole AMQP session: the response frame arrives at a channel the client has
+    /// already removed from its map, causing "session channel N cannot be found" at
+    /// the client, which tears down the connection. Using DetachSent avoids sending
+    /// any frame and still allows AMQPNetLite to cleanly remove the link from the
+    /// session's local channel map (Session.RemoveLink is called unconditionally).
     /// </summary>
     private static void HandleLinkClose(Event protocolEvent)
     {
@@ -129,55 +139,12 @@ public class GuidDeliveryTagHandler : IHandler
         {
             var currentState = (int)(LinkStateField.GetValue(link) ?? -1);
 
-            if (currentState == LinkStateStart)
+            if (currentState == LinkStateStart || currentState == LinkStateAttachSent)
             {
-                // Link is in Start state — Attach handshake never completed.
-                // Use CompleteAttach(error) to properly register the link in the
-                // session channel map and send Attach+Detach for clean shutdown.
-                if (link is ListenerLink listenerLink)
-                {
-                    try
-                    {
-                        var responseAttach = new Attach
-                        {
-                            LinkName = link.Name,
-                            Role = link.Role,
-                        };
-                        listenerLink.CompleteAttach(responseAttach, new Error(new Symbol("amqp:detach-forced"))
-                        {
-                            Description = "Link detached before attach completed."
-                        });
-                        Log.LogDebug(
-                            "Handled premature close for link '{LinkName}' via CompleteAttach (was Start state, event={EventId})",
-                            link.Name, protocolEvent.Id);
-                        return;
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.LogDebug(ex,
-                            "CompleteAttach failed for link '{LinkName}' (Start state), falling back to state transition",
-                            link.Name);
-                    }
-                }
-
-                // Fallback: if CompleteAttach failed (session/connection closing) or
-                // link is not a ListenerLink, force state to Attached so AMQPNetLite's
-                // Detach processing doesn't throw AmqpException.
-                LinkStateField.SetValue(link, (LinkState)LinkStateAttached);
-                Log.LogWarning(
-                    "Prevented detach crash: transitioned link '{LinkName}' from Start→Attached (event={EventId})",
-                    link.Name, protocolEvent.Id);
-            }
-            else if (currentState == LinkStateAttachSent)
-            {
-                // AttachSent: our Attach response was sent (Session.AddLink already called),
-                // but we haven't received the client's Attach response yet. The session
-                // channel map is already consistent. Just transition to Attached so the
-                // Detach state machine check passes.
-                LinkStateField.SetValue(link, (LinkState)LinkStateAttached);
+                LinkStateField.SetValue(link, (LinkState)LinkStateDetachSent);
                 Log.LogDebug(
-                    "Handled premature close for link '{LinkName}': AttachSent→Attached (event={EventId})",
-                    link.Name, protocolEvent.Id);
+                    "Handled premature close for link '{LinkName}': state {OldState}→DetachSent (event={EventId})",
+                    link.Name, currentState, protocolEvent.Id);
             }
         }
         catch (Exception ex)

--- a/src/AlmostServiceBus.Core/Amqp/ManagementLinkEndpoint.cs
+++ b/src/AlmostServiceBus.Core/Amqp/ManagementLinkEndpoint.cs
@@ -276,14 +276,15 @@ public class ManagementLinkEndpoint : IRequestProcessor
 
         if (anyNotFound)
         {
-            // Status 410 (Gone) with the com.microsoft:message-lock-lost condition tells
-            // the SDK that the lock is definitively lost — the message was already settled,
-            // swept, or the lock expired. The SDK will propagate MessageLockLostException
-            // to the consumer instead of continuing to renew a dead lock.
+            // Status 410 (Gone) + com.microsoft:message-lock-lost condition tells the SDK
+            // that the lock is definitively lost — the message was already settled, swept,
+            // or its lock expired. The SDK propagates MessageLockLostException to the
+            // consumer instead of continuing to renew a dead lock.
             Log.LogDebug("HandleRenewLock: lock token {Token} not found — returning MessageLockLost",
                 notFoundToken);
             SendErrorResponse(requestContext, 410,
-                $"The lock supplied is invalid. Either the lock expired, or the message has already been removed from the queue. Token: {notFoundToken}");
+                $"The lock supplied is invalid. Either the lock expired, or the message has already been removed from the queue. Token: {notFoundToken}",
+                errorCondition: "com.microsoft:message-lock-lost");
             return;
         }
 
@@ -344,7 +345,13 @@ public class ManagementLinkEndpoint : IRequestProcessor
             Log.LogWarning(
                 "HandleRenewSessionLock: session '{SessionId}' not found or not locked. Known sessions: [{Sessions}]",
                 sessionId, string.Join(", ", sessionManager.GetSessionIds()));
-            SendErrorResponse(requestContext, 404, "Session not found or not locked");
+            // 410 (Gone) + com.microsoft:session-lock-lost condition is what real Azure
+            // Service Bus returns when a session's lock has expired or been released.
+            // The SDK parses the errorCondition ApplicationProperty to map to
+            // ServiceBusFailureReason.SessionLockLost.
+            SendErrorResponse(requestContext, 410,
+                $"The session lock was lost. Session '{sessionId}' is no longer locked.",
+                errorCondition: "com.microsoft:session-lock-lost");
             return;
         }
 
@@ -482,7 +489,7 @@ public class ManagementLinkEndpoint : IRequestProcessor
         return null;
     }
 
-    private void SendErrorResponse(RequestContext requestContext, int statusCode, string description)
+    private void SendErrorResponse(RequestContext requestContext, int statusCode, string description, string? errorCondition = null)
     {
         var response = new Message()
         {
@@ -493,6 +500,16 @@ public class ManagementLinkEndpoint : IRequestProcessor
             },
             Properties = new Properties { CorrelationId = requestContext.Message.Properties?.MessageId }
         };
+
+        // The Azure SDK reads ApplicationProperties["errorCondition"] to determine the
+        // specific ServiceBusFailureReason (see AmqpResponseMessage.GetErrorCondition
+        // + AmqpExceptionHelper.ToMessagingContractException in azure-sdk-for-net).
+        // The value must be an AMQP Symbol matching a com.microsoft:* error string.
+        if (errorCondition is not null)
+        {
+            response.ApplicationProperties["errorCondition"] = new global::Amqp.Types.Symbol(errorCondition);
+        }
+
         requestContext.Complete(response);
     }
 

--- a/src/AlmostServiceBus.Core/Amqp/ManagementLinkEndpoint.cs
+++ b/src/AlmostServiceBus.Core/Amqp/ManagementLinkEndpoint.cs
@@ -215,6 +215,8 @@ public class ManagementLinkEndpoint : IRequestProcessor
     private void HandleRenewLock(RequestContext requestContext)
     {
         var expirations = new List<DateTime>();
+        bool anyNotFound = false;
+        Guid? notFoundToken = null;
 
         if (requestContext.Message.Body is Map renewBody
             && TryGetMapValue(renewBody, "lock-tokens", out var tokensObj)
@@ -252,8 +254,37 @@ public class ManagementLinkEndpoint : IRequestProcessor
                     }
                 }
 
-                expirations.Add(newExpiry?.UtcDateTime ?? DateTime.UtcNow.AddMinutes(5));
+                if (newExpiry.HasValue)
+                {
+                    expirations.Add(newExpiry.Value.UtcDateTime);
+                }
+                else
+                {
+                    // Lock token not found — message was completed, abandoned, or its lock
+                    // expired and it was re-enqueued with a new token. Surface this to the
+                    // SDK as MessageLockLost so it stops trying to renew a dead lock and
+                    // propagates the error to the consumer. Previously we returned a fake
+                    // 5-minute expiration, which caused the SDK to believe renewal succeeded
+                    // and then stop renewing — leading to R-DUPE when the actual message
+                    // lock expired under load.
+                    anyNotFound = true;
+                    notFoundToken = lockGuid;
+                    break;
+                }
             }
+        }
+
+        if (anyNotFound)
+        {
+            // Status 410 (Gone) with the com.microsoft:message-lock-lost condition tells
+            // the SDK that the lock is definitively lost — the message was already settled,
+            // swept, or the lock expired. The SDK will propagate MessageLockLostException
+            // to the consumer instead of continuing to renew a dead lock.
+            Log.LogDebug("HandleRenewLock: lock token {Token} not found — returning MessageLockLost",
+                notFoundToken);
+            SendErrorResponse(requestContext, 410,
+                $"The lock supplied is invalid. Either the lock expired, or the message has already been removed from the queue. Token: {notFoundToken}");
+            return;
         }
 
         var responseBody = new Map

--- a/src/AlmostServiceBus.Core/Amqp/ReceiverLinkEndpoint.cs
+++ b/src/AlmostServiceBus.Core/Amqp/ReceiverLinkEndpoint.cs
@@ -205,24 +205,7 @@ public class ReceiverLinkEndpoint : LinkEndpoint
                 _queue.Abandon(lockToken);
                 break;
             case Rejected rejected:
-                // The Azure SDK sends dead-letter reason/description in the Error.Info map.
-                // Condition is "com.microsoft:dead-letter", and Info contains the user-specified
-                // "DeadLetterReason" and "DeadLetterErrorDescription".
-                string? dlReason = rejected.Error?.Condition?.ToString();
-                string? dlDescription = rejected.Error?.Description;
-                if (rejected.Error?.Info is { } info)
-                {
-                    // AMQPNetLite deserializes Info map keys as Symbol, not string,
-                    // so we iterate and compare via ToString().
-                    foreach (var key in info.Keys)
-                    {
-                        var keyStr = key?.ToString();
-                        if (keyStr == "DeadLetterReason" && info[key] is string reason)
-                            dlReason = reason;
-                        if (keyStr == "DeadLetterErrorDescription" && info[key] is string desc)
-                            dlDescription = desc;
-                    }
-                }
+                var (dlReason, dlDescription) = ExtractDeadLetterInfoStatic(rejected);
                 _queue.DeadLetter(lockToken, dlReason, dlDescription);
                 break;
             case Modified modified:
@@ -235,6 +218,31 @@ public class ReceiverLinkEndpoint : LinkEndpoint
                 _queue.Complete(lockToken);
                 break;
         }
+    }
+
+    /// <summary>
+    /// Extracts the dead-letter reason and description from a Rejected delivery state.
+    /// The Azure SDK sends dead-letter reason/description in the Error.Info map
+    /// (Condition is "com.microsoft:dead-letter", and Info contains the user-specified
+    /// "DeadLetterReason" and "DeadLetterErrorDescription"). AMQPNetLite deserializes
+    /// Info map keys as Symbol, so we iterate and compare via ToString().
+    /// </summary>
+    internal static (string? Reason, string? Description) ExtractDeadLetterInfoStatic(Rejected rejected)
+    {
+        string? dlReason = rejected.Error?.Condition?.ToString();
+        string? dlDescription = rejected.Error?.Description;
+        if (rejected.Error?.Info is { } info)
+        {
+            foreach (var key in info.Keys)
+            {
+                var keyStr = key?.ToString();
+                if (keyStr == "DeadLetterReason" && info[key] is string reason)
+                    dlReason = reason;
+                if (keyStr == "DeadLetterErrorDescription" && info[key] is string desc)
+                    dlDescription = desc;
+            }
+        }
+        return (dlReason, dlDescription);
     }
 
     public async Task<BrokeredMessage> DequeueAsync(CancellationToken cancellationToken = default)

--- a/src/AlmostServiceBus.Core/Amqp/ServiceBusLinkProcessor.cs
+++ b/src/AlmostServiceBus.Core/Amqp/ServiceBusLinkProcessor.cs
@@ -260,6 +260,23 @@ public class ServiceBusLinkProcessor : ILinkProcessor
 
     private static void CompleteSessionAttach(AttachContext attachContext, QueueEntity queue, BrokerSessionState session)
     {
+        // Reclaim any pending messages orphaned by a previous receiver of this session.
+        // Because we just locked the session (via TryAcceptSession), any pending messages
+        // in _queue._pending for this session must be from a previous (dead) receiver —
+        // we haven't dequeued anything yet on this new link. Re-enqueuing them back to
+        // the session queue lets us process them in order.
+        //
+        // This replaces the OnLinkClosed-based reclaim, which caused R-DUPE cascades by
+        // racing with in-flight settlements from the closing receiver.
+        try
+        {
+            queue.ReclaimPendingForSession(session.SessionId);
+        }
+        catch (Exception ex)
+        {
+            Log.LogDebug(ex, "ReclaimPendingForSession failed for session '{SessionId}'", session.SessionId);
+        }
+
         // Create a fresh Properties map — do NOT inherit the client's Attach properties
         // (e.g. com.microsoft:timeout), which would confuse the SDK into thinking the
         // response is a timeout notification rather than a successful session accept.

--- a/src/AlmostServiceBus.Core/Amqp/ServiceBusLinkProcessor.cs
+++ b/src/AlmostServiceBus.Core/Amqp/ServiceBusLinkProcessor.cs
@@ -280,8 +280,13 @@ public class ServiceBusLinkProcessor : ILinkProcessor
         // Create a fresh Properties map — do NOT inherit the client's Attach properties
         // (e.g. com.microsoft:timeout), which would confuse the SDK into thinking the
         // response is a timeout notification rather than a successful session accept.
+        //
+        // CRITICAL: The Azure SDK reads com.microsoft:locked-until-utc as a `long`
+        // (UTC ticks) — not a DateTime. See AmqpReceiver.OpenReceiverLinkAsync in
+        // azure-sdk-for-net. Sending DateTime causes TryGetValue<long> to fail and
+        // SessionLockedUntil becomes DateTime.MinValue on the SDK side.
         attachContext.Attach.Properties = new Fields();
-        attachContext.Attach.Properties[new Symbol("com.microsoft:locked-until-utc")] = session.LockedUntil.UtcDateTime;
+        attachContext.Attach.Properties[new Symbol("com.microsoft:locked-until-utc")] = session.LockedUntil.UtcTicks;
         attachContext.Attach.Properties[new Symbol("com.microsoft:session-id")] = session.SessionId;
 
         // The Azure SDK also reads the resolved session ID from the Source filter-set

--- a/src/AlmostServiceBus.Core/Amqp/SessionReceiverLinkEndpoint.cs
+++ b/src/AlmostServiceBus.Core/Amqp/SessionReceiverLinkEndpoint.cs
@@ -183,12 +183,18 @@ public class SessionReceiverLinkEndpoint : LinkEndpoint
             // Release the session lock so a new receiver can pick up this session
             // immediately. Under high load (e.g. connection resets), holding the lock
             // for the full LockDuration (30s) starves new receivers and causes messages
-            // to pile up. The RenewSessionLock 404 race (see below) is acceptable
-            // because if the link is closing, the client is already tearing down.
+            // to pile up.
             //
-            // Note: in normal SDK-initiated close, the SDK releases the session lock
-            // explicitly via $management before closing the link. This path handles
-            // abnormal closes (connection resets, timeouts).
+            // Note: we do NOT reclaim pending messages here. If the client's settlement
+            // for a message was in-flight when the link closed, reclaiming immediately
+            // would race: the settlement might arrive for the old receiver, but the
+            // re-enqueued message is already being processed by a new receiver, causing
+            // R-DUPE cascades via published events.
+            //
+            // Instead, ReclaimPendingForSession is called when a NEW receiver accepts
+            // this session (see ServiceBusLinkProcessor). At that point, any pending
+            // messages for this session must be from a previous (dead) receiver, so
+            // reclaiming is safe.
             try
             {
                 _queue.Sessions?.ReleaseSession(_session.SessionId);
@@ -198,21 +204,6 @@ public class SessionReceiverLinkEndpoint : LinkEndpoint
             catch (Exception ex)
             {
                 Log.LogDebug(ex, "Failed to release session lock for '{SessionId}'", _session.SessionId);
-            }
-
-            // Reclaim any pending (in-flight) messages back to the session queue.
-            // When the pump was running, it dequeued messages from the session and
-            // tracked them in _queue._pending. With the link dead, those messages
-            // would be stuck in _pending until SweepExpiredLocks picks them up (up
-            // to LockDuration delay). Reclaiming them immediately allows the next
-            // receiver to process them without waiting.
-            try
-            {
-                _queue.ReclaimPendingForSession(_session.SessionId);
-            }
-            catch (Exception ex)
-            {
-                Log.LogDebug(ex, "Failed to reclaim pending messages for session '{SessionId}'", _session.SessionId);
             }
         }
         catch (Exception ex)

--- a/src/AlmostServiceBus.Core/Amqp/SessionReceiverLinkEndpoint.cs
+++ b/src/AlmostServiceBus.Core/Amqp/SessionReceiverLinkEndpoint.cs
@@ -130,9 +130,12 @@ public class SessionReceiverLinkEndpoint : LinkEndpoint
                         _queue.Abandon(lockToken);
                         break;
                     case Rejected rejected:
-                        _queue.DeadLetter(lockToken,
-                            rejected.Error?.Condition?.ToString(),
-                            rejected.Error?.Description);
+                        // Use the shared helper so the Azure SDK's DeadLetterReason /
+                        // DeadLetterErrorDescription (sent in Error.Info map) are
+                        // extracted consistently on session and non-session queues.
+                        var (dlReason, dlDescription) =
+                            ReceiverLinkEndpoint.ExtractDeadLetterInfoStatic(rejected);
+                        _queue.DeadLetter(lockToken, dlReason, dlDescription);
                         break;
                     case Modified modified:
                         if (modified.UndeliverableHere == true)

--- a/src/AlmostServiceBus.Core/Broker/QueueEntity.cs
+++ b/src/AlmostServiceBus.Core/Broker/QueueEntity.cs
@@ -442,15 +442,35 @@ public sealed class QueueEntity : IDisposable
     /// <summary>
     /// Renews the lock on a pending message, extending <see cref="BrokeredMessage.LockedUntil"/>
     /// by <see cref="LockDuration"/>. Returns the new <see cref="BrokeredMessage.LockedUntil"/>
-    /// time, or <see langword="null"/> if the message was not found in pending.
+    /// time, or <see langword="null"/> if the message was not found in pending (it was
+    /// completed, abandoned, or its lock was swept and re-enqueued under a new token).
+    ///
+    /// Race-safe: if <see cref="SweepExpiredLocks"/> runs concurrently and moves the
+    /// message out of _pending (via ReEnqueueExpired, which sets LockToken=null before
+    /// re-enqueueing), the final check catches it and returns null so the caller knows
+    /// the renewal is invalid.
     /// </summary>
     public DateTimeOffset? RenewLock(string lockToken)
     {
         if (!_pending.TryGetValue(lockToken, out var message))
             return null;
 
-        message.LockedUntil = DateTimeOffset.UtcNow.Add(LockDuration);
-        return message.LockedUntil;
+        var newExpiry = DateTimeOffset.UtcNow.Add(LockDuration);
+        message.LockedUntil = newExpiry;
+
+        // Race check: if the sweep concurrently re-enqueued this message between
+        // our TryGetValue and our LockedUntil write, it will have cleared LockToken
+        // (see ReEnqueueExpired → ReEnqueue). If the token no longer matches, our
+        // renewal landed on a message that's no longer under this lock token.
+        if (!string.Equals(message.LockToken, lockToken, StringComparison.Ordinal))
+            return null;
+
+        // Belt-and-braces: also confirm the message is still in _pending. If it was
+        // removed (completed/abandoned/swept) after our TryGetValue, the renewal is void.
+        if (!_pending.ContainsKey(lockToken))
+            return null;
+
+        return newExpiry;
     }
 
     /// <summary>
@@ -516,9 +536,19 @@ public sealed class QueueEntity : IDisposable
     private void SweepExpiredLocks()
     {
         var now = DateTimeOffset.UtcNow;
+        // Grace period: don't re-enqueue immediately when a lock expires. Auto-renewal
+        // requests from the SDK may be in flight, and under high CPU load the management
+        // request processing can lag by a few seconds. Without a grace period, the sweep
+        // races with auto-renewal: it re-enqueues a message whose consumer is still alive
+        // and about to renew, causing R-DUPE cascades.
+        //
+        // The grace is 10% of LockDuration (e.g. 6s for 60s locks, 3s for 30s locks,
+        // proportional for shorter test locks).
+        var graceTicks = Math.Max(LockDuration.Ticks / 10, TimeSpan.FromMilliseconds(1).Ticks);
+        var sweepThreshold = now - new TimeSpan(graceTicks);
         foreach (var (lockToken, message) in _pending)
         {
-            if (message.LockedUntil != default && now > message.LockedUntil)
+            if (message.LockedUntil != default && sweepThreshold > message.LockedUntil)
             {
                 // For session-enabled queues, the session lock governs message lifetime.
                 // Only sweep messages whose session lock has ALSO expired or been released.

--- a/src/AlmostServiceBus.Core/Hosting/EmulatorInfrastructure.cs
+++ b/src/AlmostServiceBus.Core/Hosting/EmulatorInfrastructure.cs
@@ -31,7 +31,7 @@ public static class EmulatorInfrastructure
         store.Open(OpenFlags.ReadOnly);
         // OID 1.3.6.1.4.1.311.84.1.1 identifies ASP.NET Core dev certs
         var certs = store.Certificates.Find(
-            X509FindType.FindByExtension, "1.3.6.1.4.1.311.84.1.1", validOnly: false);
+            X509FindType.FindByExtension, "1.3.6.1.4.1.311.84.1.1", validOnly: true);
         if (certs.Count == 0)
             throw new InvalidOperationException(
                 "ASP.NET HTTPS development certificate not found. " +

--- a/src/AlmostServiceBus.Core/Hosting/EmulatorInfrastructure.cs
+++ b/src/AlmostServiceBus.Core/Hosting/EmulatorInfrastructure.cs
@@ -21,22 +21,25 @@ public static class EmulatorInfrastructure
         return port;
     }
 
+    const string AspNetHttpsOid = "1.3.6.1.4.1.311.84.1.1";
+    
     /// <summary>
     /// Loads the ASP.NET Core HTTPS development certificate from the current user's certificate store.
     /// Throws if no dev cert is found.
     /// </summary>
-    public static X509Certificate2 LoadDevCert()
+    public static X509Certificate2? LoadDevCert()
     {
         using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
         store.Open(OpenFlags.ReadOnly);
-        // OID 1.3.6.1.4.1.311.84.1.1 identifies ASP.NET Core dev certs
-        var certs = store.Certificates.Find(
-            X509FindType.FindByExtension, "1.3.6.1.4.1.311.84.1.1", validOnly: true);
-        if (certs.Count == 0)
-            throw new InvalidOperationException(
-                "ASP.NET HTTPS development certificate not found. " +
-                "Run 'dotnet dev-certs https --trust' to generate and trust the certificate.");
-        return new X509Certificate2(certs[0]);
+        var now = DateTime.Now;
+        return store.Certificates
+            .OfType<X509Certificate2>()
+            .Where(c => c.Extensions.OfType<X509Extension>()
+                .Any(e => e.Oid?.Value == AspNetHttpsOid))
+            .Where(c => c.Subject == "CN=localhost")
+            .Where(c => c.HasPrivateKey && c.NotBefore <= now && now <= c.NotAfter)
+            .OrderByDescending(c => c.NotAfter)
+            .FirstOrDefault();
     }
 
     /// <summary>

--- a/src/AlmostServiceBus.Host/Program.cs
+++ b/src/AlmostServiceBus.Host/Program.cs
@@ -5,6 +5,22 @@ using AlmostServiceBus.Core.Hosting;
 using AlmostServiceBus.Core.Management;
 using Vite.AspNetCore;
 
+// Enable AMQPNetLite frame tracing for diagnostic builds. Set TRACE_AMQP=1 env var.
+if (Environment.GetEnvironmentVariable("TRACE_AMQP") == "1")
+{
+    Console.Error.WriteLine("[TRACE] Enabling AMQP frame tracing");
+    Amqp.Trace.TraceLevel = Amqp.TraceLevel.Frame;
+    Amqp.Trace.TraceListener = (level, format, args) =>
+    {
+        try
+        {
+            var line = args != null && args.Length > 0 ? string.Format(format, args) : format;
+            Console.Error.WriteLine($"[AMQP] {line}");
+        }
+        catch (Exception ex) { Console.Error.WriteLine($"[AMQP-TRACE-ERR] {ex.Message}"); }
+    };
+}
+
 // ── Management API server (internal, behind TLS multiplexer) ──
 
 var mgmtBuilder = WebApplication.CreateBuilder(args);

--- a/tests/ms-emulator-comparison/LockRenewalComparison/Config.json
+++ b/tests/ms-emulator-comparison/LockRenewalComparison/Config.json
@@ -1,0 +1,37 @@
+{
+  "UserConfig": {
+    "Namespaces": [
+      {
+        "Name": "sbemulatorns",
+        "Queues": [
+          {
+            "Name": "lock-renewal-queue",
+            "Properties": {
+              "LockDuration": "PT10S",
+              "MaxDeliveryCount": 10,
+              "RequiresSession": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "DuplicateDetectionHistoryTimeWindow": "PT20S",
+              "RequiresDuplicateDetection": false
+            }
+          },
+          {
+            "Name": "session-renewal-queue",
+            "Properties": {
+              "LockDuration": "PT10S",
+              "MaxDeliveryCount": 10,
+              "RequiresSession": true,
+              "DefaultMessageTimeToLive": "PT1H",
+              "DuplicateDetectionHistoryTimeWindow": "PT20S",
+              "RequiresDuplicateDetection": false
+            }
+          }
+        ],
+        "Topics": []
+      }
+    ],
+    "Logging": {
+      "Type": "Console"
+    }
+  }
+}

--- a/tests/ms-emulator-comparison/LockRenewalComparison/LockRenewalComparison.csproj
+++ b/tests/ms-emulator-comparison/LockRenewalComparison/LockRenewalComparison.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ms-emulator-comparison/LockRenewalComparison/LockRenewalTests.cs
+++ b/tests/ms-emulator-comparison/LockRenewalComparison/LockRenewalTests.cs
@@ -1,0 +1,305 @@
+using Azure.Messaging.ServiceBus;
+using Xunit.Abstractions;
+
+namespace LockRenewalComparison;
+
+/// <summary>
+/// Lock-renewal behavior tests that run against BOTH Microsoft's official
+/// Azure Service Bus emulator and our AlmostServiceBus emulator. The connection
+/// string comes from the SBE_CONNECTION_STRING environment variable. A
+/// test run produces a "result.txt" with pass/fail for each scenario — running
+/// against both emulators and diff'ing the files reveals where we diverge.
+///
+/// The focus is on correctness of:
+///  - Message-lock renewal (RenewMessageLockAsync)
+///  - Session-lock renewal (RenewSessionLockAsync)
+///  - Error modes: MessageLockLost, SessionLockLost, MessageNotFound
+///
+/// Queues expected to exist (see Config.json for MS emulator, or auto-created
+/// for ours): "lock-renewal-queue" (no sessions, 10s lock) and
+/// "session-renewal-queue" (sessions, 10s lock).
+/// </summary>
+public class LockRenewalTests : IAsyncLifetime
+{
+    private const string QueueName = "lock-renewal-queue";
+    private const string SessionQueueName = "session-renewal-queue";
+
+    private readonly ITestOutputHelper _output;
+    private ServiceBusClient _client = null!;
+
+    public LockRenewalTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public Task InitializeAsync()
+    {
+        var connectionString = Environment.GetEnvironmentVariable("SBE_CONNECTION_STRING")
+            ?? throw new InvalidOperationException(
+                "SBE_CONNECTION_STRING environment variable is required. " +
+                "For MS emulator: Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true " +
+                "For ours: Endpoint=sb://localhost:5672;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=emulator");
+
+        _client = new ServiceBusClient(connectionString);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _client.DisposeAsync();
+    }
+
+    // ---------------------------------------------------------------- Message lock tests
+
+    [Fact]
+    public async Task MessageLock_RenewExtendsExpiry()
+    {
+        await using var sender = _client.CreateSender(QueueName);
+        await using var receiver = _client.CreateReceiver(QueueName,
+            new ServiceBusReceiverOptions { ReceiveMode = ServiceBusReceiveMode.PeekLock });
+
+        await sender.SendMessageAsync(new ServiceBusMessage("renew-me") { MessageId = Guid.NewGuid().ToString() });
+        var msg = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(10));
+        Assert.NotNull(msg);
+
+        var originalExpiry = msg.LockedUntil;
+        _output.WriteLine($"Original expiry: {originalExpiry:O}");
+
+        await receiver.RenewMessageLockAsync(msg);
+
+        _output.WriteLine($"New expiry:      {msg.LockedUntil:O}");
+        Assert.True(msg.LockedUntil > originalExpiry,
+            $"LockedUntil should advance. Before: {originalExpiry:O}, After: {msg.LockedUntil:O}");
+
+        await receiver.CompleteMessageAsync(msg);
+    }
+
+    [Fact]
+    public async Task MessageLock_RenewAfterComplete_ThrowsMessageLockLost()
+    {
+        await using var sender = _client.CreateSender(QueueName);
+        await using var receiver = _client.CreateReceiver(QueueName);
+
+        await sender.SendMessageAsync(new ServiceBusMessage("complete-then-renew")
+        { MessageId = Guid.NewGuid().ToString() });
+        var msg = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(10));
+        Assert.NotNull(msg);
+        await receiver.CompleteMessageAsync(msg);
+
+        // Now try to renew — must fail with MessageLockLost.
+        var ex = await Assert.ThrowsAsync<ServiceBusException>(
+            () => receiver.RenewMessageLockAsync(msg));
+        _output.WriteLine($"Reason: {ex.Reason}");
+        Assert.Equal(ServiceBusFailureReason.MessageLockLost, ex.Reason);
+    }
+
+    [Fact]
+    public async Task MessageLock_RenewAfterAbandon_ThrowsMessageLockLost()
+    {
+        await using var sender = _client.CreateSender(QueueName);
+        await using var receiver = _client.CreateReceiver(QueueName);
+
+        await sender.SendMessageAsync(new ServiceBusMessage("abandon-then-renew")
+        { MessageId = Guid.NewGuid().ToString() });
+        var msg = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(10));
+        Assert.NotNull(msg);
+        await receiver.AbandonMessageAsync(msg);
+
+        var ex = await Assert.ThrowsAsync<ServiceBusException>(
+            () => receiver.RenewMessageLockAsync(msg));
+        _output.WriteLine($"Reason: {ex.Reason}");
+        Assert.Equal(ServiceBusFailureReason.MessageLockLost, ex.Reason);
+
+        // Drain the re-delivered message to keep queue clean.
+        var redelivered = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(10));
+        if (redelivered is not null)
+            await receiver.CompleteMessageAsync(redelivered);
+    }
+
+    [Fact]
+    public async Task MessageLock_RenewAfterNaturalExpiry_ThrowsMessageLockLost()
+    {
+        await using var sender = _client.CreateSender(QueueName);
+        await using var receiver = _client.CreateReceiver(QueueName);
+
+        await sender.SendMessageAsync(new ServiceBusMessage("expire-then-renew")
+        { MessageId = Guid.NewGuid().ToString() });
+        var msg = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(10));
+        Assert.NotNull(msg);
+
+        // Wait past the 10-second LockDuration so the broker expires and re-enqueues
+        // the message. The broker should assign a new lock token to the re-delivered
+        // copy, making the original one we hold invalid.
+        _output.WriteLine($"Sleeping past lock expiry {msg.LockedUntil:O}...");
+        var waitSpan = msg.LockedUntil - DateTimeOffset.UtcNow + TimeSpan.FromSeconds(12);
+        if (waitSpan > TimeSpan.Zero)
+            await Task.Delay(waitSpan);
+
+        var ex = await Assert.ThrowsAsync<ServiceBusException>(
+            () => receiver.RenewMessageLockAsync(msg));
+        _output.WriteLine($"Reason: {ex.Reason}");
+        Assert.Equal(ServiceBusFailureReason.MessageLockLost, ex.Reason);
+
+        // Drain the re-delivered message.
+        var redelivered = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(15));
+        if (redelivered is not null)
+            await receiver.CompleteMessageAsync(redelivered);
+    }
+
+    [Fact]
+    public async Task MessageLock_RenewMultipleTimes_Succeeds()
+    {
+        await using var sender = _client.CreateSender(QueueName);
+        await using var receiver = _client.CreateReceiver(QueueName);
+
+        await sender.SendMessageAsync(new ServiceBusMessage("renew-3x")
+        { MessageId = Guid.NewGuid().ToString() });
+        var msg = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(10));
+        Assert.NotNull(msg);
+
+        for (int i = 0; i < 3; i++)
+        {
+            var before = msg.LockedUntil;
+            await Task.Delay(500);
+            await receiver.RenewMessageLockAsync(msg);
+            _output.WriteLine($"Renewal {i + 1}: {before:O} -> {msg.LockedUntil:O}");
+            Assert.True(msg.LockedUntil > before);
+        }
+
+        await receiver.CompleteMessageAsync(msg);
+    }
+
+    // ---------------------------------------------------------------- Session lock tests
+
+    [Fact]
+    public async Task SessionLock_RenewExtendsExpiry()
+    {
+        var sessionId = $"s-{Guid.NewGuid():N}";
+        await using var sender = _client.CreateSender(SessionQueueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("in-session")
+        {
+            MessageId = Guid.NewGuid().ToString(),
+            SessionId = sessionId
+        });
+
+        await using var receiver = await _client.AcceptSessionAsync(SessionQueueName, sessionId);
+        var originalExpiry = receiver.SessionLockedUntil;
+        _output.WriteLine($"Original session expiry: {originalExpiry:O}");
+
+        await Task.Delay(500);
+        await receiver.RenewSessionLockAsync();
+
+        _output.WriteLine($"New session expiry:      {receiver.SessionLockedUntil:O}");
+        Assert.True(receiver.SessionLockedUntil > originalExpiry,
+            $"SessionLockedUntil should advance. Before: {originalExpiry:O}, After: {receiver.SessionLockedUntil:O}");
+
+        // Consume the test message so the next test run starts clean.
+        var msg = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
+        if (msg is not null) await receiver.CompleteMessageAsync(msg);
+    }
+
+    [Fact]
+    public async Task SessionLock_RenewAfterNaturalExpiry_ThrowsSessionLockLost()
+    {
+        var sessionId = $"s-{Guid.NewGuid():N}";
+        await using var sender = _client.CreateSender(SessionQueueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("session-expires")
+        {
+            MessageId = Guid.NewGuid().ToString(),
+            SessionId = sessionId
+        });
+
+        var receiver = await _client.AcceptSessionAsync(SessionQueueName, sessionId);
+        var expiry = receiver.SessionLockedUntil;
+        _output.WriteLine($"Session expires at {expiry:O}");
+
+        // Wait well past LockDuration so the session lock expires server-side.
+        var waitSpan = expiry - DateTimeOffset.UtcNow + TimeSpan.FromSeconds(12);
+        if (waitSpan > TimeSpan.Zero)
+            await Task.Delay(waitSpan);
+
+        var ex = await Assert.ThrowsAsync<ServiceBusException>(
+            () => receiver.RenewSessionLockAsync());
+        _output.WriteLine($"Reason: {ex.Reason}");
+        Assert.Equal(ServiceBusFailureReason.SessionLockLost, ex.Reason);
+
+        await receiver.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task SessionLock_RenewMultipleTimes_Succeeds()
+    {
+        var sessionId = $"s-{Guid.NewGuid():N}";
+        await using var sender = _client.CreateSender(SessionQueueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("multi-renew")
+        {
+            MessageId = Guid.NewGuid().ToString(),
+            SessionId = sessionId
+        });
+
+        await using var receiver = await _client.AcceptSessionAsync(SessionQueueName, sessionId);
+
+        for (int i = 0; i < 3; i++)
+        {
+            var before = receiver.SessionLockedUntil;
+            await Task.Delay(500);
+            await receiver.RenewSessionLockAsync();
+            _output.WriteLine($"Session renewal {i + 1}: {before:O} -> {receiver.SessionLockedUntil:O}");
+            Assert.True(receiver.SessionLockedUntil > before);
+        }
+
+        var msg = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
+        if (msg is not null) await receiver.CompleteMessageAsync(msg);
+    }
+
+    // ---------------------------------------------------------------- High-throughput simulation
+
+    [Fact]
+    public async Task MessageLock_AutoRenewalSurvivesSlowConsumer()
+    {
+        // This test exercises the exact scenario that causes R-DUPE cascades under
+        // Black Friday load: a consumer that holds a message longer than LockDuration
+        // and relies on the SDK's built-in lock auto-renewal to keep it alive.
+        await using var sender = _client.CreateSender(QueueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("slow-processing")
+        { MessageId = Guid.NewGuid().ToString() });
+
+        var processedOk = false;
+        await using var processor = _client.CreateProcessor(QueueName, new ServiceBusProcessorOptions
+        {
+            MaxConcurrentCalls = 1,
+            AutoCompleteMessages = false,
+            MaxAutoLockRenewalDuration = TimeSpan.FromMinutes(2),
+            ReceiveMode = ServiceBusReceiveMode.PeekLock,
+        });
+
+        processor.ProcessMessageAsync += async args =>
+        {
+            _output.WriteLine($"Got message, sleeping 25s (lock is 10s, auto-renewal must kick in)...");
+            await Task.Delay(TimeSpan.FromSeconds(25), args.CancellationToken);
+            try
+            {
+                await args.CompleteMessageAsync(args.Message, args.CancellationToken);
+                processedOk = true;
+                _output.WriteLine("Completed successfully — auto-renewal worked.");
+            }
+            catch (Exception ex)
+            {
+                _output.WriteLine($"Complete failed: {ex.GetType().Name}: {ex.Message}");
+            }
+        };
+        processor.ProcessErrorAsync += args =>
+        {
+            _output.WriteLine($"ERR: {args.Exception.GetType().Name}: {args.Exception.Message}");
+            return Task.CompletedTask;
+        };
+
+        await processor.StartProcessingAsync();
+        // Give it long enough for the 25s sleep + complete to finish.
+        for (int i = 0; i < 40 && !processedOk; i++)
+            await Task.Delay(TimeSpan.FromSeconds(1));
+        await processor.StopProcessingAsync();
+
+        Assert.True(processedOk, "SDK auto-renewal must keep the lock alive across slow processing.");
+    }
+}

--- a/tests/ms-emulator-comparison/LockRenewalComparison/LockRenewalTests.cs
+++ b/tests/ms-emulator-comparison/LockRenewalComparison/LockRenewalTests.cs
@@ -210,13 +210,13 @@ public class LockRenewalTests : IAsyncLifetime
         });
 
         var receiver = await _client.AcceptSessionAsync(SessionQueueName, sessionId);
-        var expiry = receiver.SessionLockedUntil;
-        _output.WriteLine($"Session expires at {expiry:O}");
+        _output.WriteLine($"Session expires (from SDK): {receiver.SessionLockedUntil:O}");
 
-        // Wait well past LockDuration so the session lock expires server-side.
-        var waitSpan = expiry - DateTimeOffset.UtcNow + TimeSpan.FromSeconds(12);
-        if (waitSpan > TimeSpan.Zero)
-            await Task.Delay(waitSpan);
+        // Wait for LockDuration (10s configured on the queue) plus grace. Don't rely
+        // on receiver.SessionLockedUntil because the Azure SDK may or may not populate
+        // it from the attach response — both emulators should agree on behavior here
+        // regardless of whether the SDK sees the initial expiry or not.
+        await Task.Delay(TimeSpan.FromSeconds(12));
 
         var ex = await Assert.ThrowsAsync<ServiceBusException>(
             () => receiver.RenewSessionLockAsync());

--- a/tests/ms-emulator-comparison/LockRenewalComparison/SessionBehaviorTests.cs
+++ b/tests/ms-emulator-comparison/LockRenewalComparison/SessionBehaviorTests.cs
@@ -1,0 +1,349 @@
+using Azure.Messaging.ServiceBus;
+using Xunit.Abstractions;
+
+namespace LockRenewalComparison;
+
+/// <summary>
+/// Session-specific behavior tests that exercise more than just lock renewal.
+/// Covers: session state, AcceptNextSession, session isolation (two receivers,
+/// two sessions), session-lock release on Dispose, message ordering within a
+/// session, and message-level operations on session queues.
+///
+/// Queues required (defined in Config.json for the MS emulator, created by the
+/// runner script for ours): "session-renewal-queue" (sessions, 10s lock).
+/// </summary>
+public class SessionBehaviorTests : IAsyncLifetime
+{
+    private const string SessionQueueName = "session-renewal-queue";
+
+    private readonly ITestOutputHelper _output;
+    private ServiceBusClient _client = null!;
+
+    public SessionBehaviorTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public Task InitializeAsync()
+    {
+        var cs = Environment.GetEnvironmentVariable("SBE_CONNECTION_STRING")
+            ?? throw new InvalidOperationException("SBE_CONNECTION_STRING is required.");
+        _client = new ServiceBusClient(cs);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync() => await _client.DisposeAsync();
+
+    // ---------------------------------------------------------------- Accept mechanics
+
+    [Fact]
+    public async Task AcceptSession_PopulatesSessionLockedUntil()
+    {
+        // Regression guard for the bug we discovered: our emulator was sending
+        // com.microsoft:locked-until-utc as a DateTime in the attach response,
+        // but the SDK reads it as `long` ticks — so SessionLockedUntil was
+        // always DateTime.MinValue. This test locks in the fix.
+        var sessionId = $"s-{Guid.NewGuid():N}";
+        await using var sender = _client.CreateSender(SessionQueueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("present")
+        { MessageId = Guid.NewGuid().ToString(), SessionId = sessionId });
+
+        await using var receiver = await _client.AcceptSessionAsync(SessionQueueName, sessionId);
+
+        _output.WriteLine($"SessionLockedUntil: {receiver.SessionLockedUntil:O}");
+        Assert.True(receiver.SessionLockedUntil > DateTimeOffset.UtcNow,
+            $"SessionLockedUntil must be in the future after accept, got {receiver.SessionLockedUntil:O}");
+    }
+
+    [Fact]
+    public async Task AcceptNextSession_ReturnsAvailableSession()
+    {
+        var sessionId = $"s-{Guid.NewGuid():N}";
+        await using var sender = _client.CreateSender(SessionQueueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("any")
+        { MessageId = Guid.NewGuid().ToString(), SessionId = sessionId });
+
+        // AcceptNextSessionAsync picks any available session with messages.
+        // It should return THIS session since we just sent to it.
+        await using var receiver = await _client.AcceptNextSessionAsync(
+            SessionQueueName,
+            new ServiceBusSessionReceiverOptions(),
+            new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token);
+
+        Assert.NotNull(receiver);
+        _output.WriteLine($"Got session: '{receiver.SessionId}'");
+        Assert.False(string.IsNullOrEmpty(receiver.SessionId));
+
+        var msg = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
+        if (msg is not null) await receiver.CompleteMessageAsync(msg);
+    }
+
+    [Fact]
+    public async Task AcceptSession_SecondReceiverIsRejectedWhileFirstHoldsLock()
+    {
+        var sessionId = $"s-{Guid.NewGuid():N}";
+        await using var sender = _client.CreateSender(SessionQueueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("locked")
+        { MessageId = Guid.NewGuid().ToString(), SessionId = sessionId });
+
+        await using var first = await _client.AcceptSessionAsync(SessionQueueName, sessionId);
+
+        // Second client attempts to lock the same session — should fail because
+        // the session is already locked. The SDK may surface this as a timeout
+        // or a SessionCannotBeLocked exception; both are acceptable signals
+        // that the lock is exclusive.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(6));
+        var caught = await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            await using var second = await _client.AcceptSessionAsync(
+                SessionQueueName, sessionId,
+                new ServiceBusSessionReceiverOptions(),
+                cts.Token);
+        });
+        _output.WriteLine($"Caught (expected): {caught.GetType().Name}: {caught.Message[..Math.Min(caught.Message.Length, 100)]}");
+    }
+
+    [Fact]
+    public async Task MultipleSessions_ReceiversAreIsolated()
+    {
+        var s1 = $"s-{Guid.NewGuid():N}";
+        var s2 = $"s-{Guid.NewGuid():N}";
+        await using var sender = _client.CreateSender(SessionQueueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("s1-msg")
+        { MessageId = Guid.NewGuid().ToString(), SessionId = s1 });
+        await sender.SendMessageAsync(new ServiceBusMessage("s2-msg")
+        { MessageId = Guid.NewGuid().ToString(), SessionId = s2 });
+
+        await using var r1 = await _client.AcceptSessionAsync(SessionQueueName, s1);
+        await using var r2 = await _client.AcceptSessionAsync(SessionQueueName, s2);
+
+        var m1 = await r1.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
+        var m2 = await r2.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
+
+        Assert.NotNull(m1);
+        Assert.NotNull(m2);
+        Assert.Equal(s1, m1.SessionId);
+        Assert.Equal(s2, m2.SessionId);
+
+        await r1.CompleteMessageAsync(m1);
+        await r2.CompleteMessageAsync(m2);
+    }
+
+    // ---------------------------------------------------------------- Message ordering
+
+    [Fact]
+    public async Task SessionMessages_DeliveredInSendOrder()
+    {
+        var sessionId = $"s-{Guid.NewGuid():N}";
+        await using var sender = _client.CreateSender(SessionQueueName);
+
+        var sentIds = new List<string>();
+        for (int i = 0; i < 5; i++)
+        {
+            var id = $"ord-{i}-{Guid.NewGuid():N}";
+            sentIds.Add(id);
+            await sender.SendMessageAsync(new ServiceBusMessage($"m-{i}")
+            { MessageId = id, SessionId = sessionId });
+        }
+
+        await using var receiver = await _client.AcceptSessionAsync(SessionQueueName, sessionId);
+        var received = new List<string>();
+        for (int i = 0; i < 5; i++)
+        {
+            var msg = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
+            Assert.NotNull(msg);
+            received.Add(msg.MessageId);
+            await receiver.CompleteMessageAsync(msg);
+        }
+
+        Assert.Equal(sentIds, received);
+    }
+
+    // ---------------------------------------------------------------- Session state
+
+    [Fact]
+    public async Task SessionState_RoundTripsBetweenReceivers()
+    {
+        var sessionId = $"s-{Guid.NewGuid():N}";
+        await using var sender = _client.CreateSender(SessionQueueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("state-anchor")
+        { MessageId = Guid.NewGuid().ToString(), SessionId = sessionId });
+
+        // First receiver sets state.
+        var expected = new byte[] { 0xAB, 0xCD, 0xEF, 0x01, 0x02, 0x03 };
+        {
+            await using var r = await _client.AcceptSessionAsync(SessionQueueName, sessionId);
+            await r.SetSessionStateAsync(BinaryData.FromBytes(expected));
+            // Consume the message so the session doesn't block indefinitely
+            // on the next accept (emulators that require messages to be
+            // drained will otherwise stall AcceptNextSession).
+            var msg = await r.ReceiveMessageAsync(TimeSpan.FromSeconds(3));
+            if (msg is not null) await r.CompleteMessageAsync(msg);
+        }
+
+        // Second receiver reads the state — must see exactly what we wrote.
+        // Send another message to keep the session alive for the second accept.
+        await sender.SendMessageAsync(new ServiceBusMessage("state-anchor-2")
+        { MessageId = Guid.NewGuid().ToString(), SessionId = sessionId });
+
+        await using var r2 = await _client.AcceptSessionAsync(SessionQueueName, sessionId);
+        var actual = await r2.GetSessionStateAsync();
+        Assert.Equal(expected, actual.ToArray());
+
+        // Cleanup
+        var m = await r2.ReceiveMessageAsync(TimeSpan.FromSeconds(3));
+        if (m is not null) await r2.CompleteMessageAsync(m);
+    }
+
+    [Fact]
+    public async Task SessionState_NullByDefault()
+    {
+        var sessionId = $"s-{Guid.NewGuid():N}";
+        await using var sender = _client.CreateSender(SessionQueueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("anchor")
+        { MessageId = Guid.NewGuid().ToString(), SessionId = sessionId });
+
+        await using var receiver = await _client.AcceptSessionAsync(SessionQueueName, sessionId);
+        var state = await receiver.GetSessionStateAsync();
+        // Both null and empty are acceptable "no state set" representations.
+        Assert.True(state is null || state.ToArray().Length == 0,
+            $"Default session state should be null or empty, got {state?.ToArray().Length ?? -1} bytes");
+
+        var m = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(3));
+        if (m is not null) await receiver.CompleteMessageAsync(m);
+    }
+
+    [Fact]
+    public async Task SessionState_CanBeClearedByPassingNull()
+    {
+        var sessionId = $"s-{Guid.NewGuid():N}";
+        await using var sender = _client.CreateSender(SessionQueueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("anchor")
+        { MessageId = Guid.NewGuid().ToString(), SessionId = sessionId });
+
+        await using var r = await _client.AcceptSessionAsync(SessionQueueName, sessionId);
+        await r.SetSessionStateAsync(BinaryData.FromBytes(new byte[] { 1, 2, 3 }));
+        // Clear it
+        await r.SetSessionStateAsync(null);
+
+        var state = await r.GetSessionStateAsync();
+        Assert.True(state is null || state.ToArray().Length == 0,
+            $"State should be cleared, got {state?.ToArray().Length ?? -1} bytes");
+
+        var m = await r.ReceiveMessageAsync(TimeSpan.FromSeconds(3));
+        if (m is not null) await r.CompleteMessageAsync(m);
+    }
+
+    // ---------------------------------------------------------------- Message settlement
+
+    [Fact]
+    public async Task SessionMessage_Abandon_RedeliversInSameSession()
+    {
+        var sessionId = $"s-{Guid.NewGuid():N}";
+        var messageId = Guid.NewGuid().ToString();
+        await using var sender = _client.CreateSender(SessionQueueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("retry-me")
+        { MessageId = messageId, SessionId = sessionId });
+
+        await using var receiver = await _client.AcceptSessionAsync(SessionQueueName, sessionId);
+
+        // First delivery → abandon.
+        var first = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
+        Assert.NotNull(first);
+        Assert.Equal(messageId, first.MessageId);
+        Assert.Equal(1, first.DeliveryCount);
+        await receiver.AbandonMessageAsync(first);
+
+        // Second delivery — same session, same message, DeliveryCount increased.
+        var second = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(10));
+        Assert.NotNull(second);
+        Assert.Equal(messageId, second.MessageId);
+        Assert.True(second.DeliveryCount >= 2,
+            $"Expected DeliveryCount >= 2 after Abandon, got {second.DeliveryCount}");
+        await receiver.CompleteMessageAsync(second);
+    }
+
+    [Fact]
+    public async Task SessionMessage_DeadLetter_MovesToDeadLetterQueue()
+    {
+        var sessionId = $"s-{Guid.NewGuid():N}";
+        var messageId = Guid.NewGuid().ToString();
+        await using var sender = _client.CreateSender(SessionQueueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("dead")
+        { MessageId = messageId, SessionId = sessionId });
+
+        await using (var receiver = await _client.AcceptSessionAsync(SessionQueueName, sessionId))
+        {
+            var msg = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
+            Assert.NotNull(msg);
+            await receiver.DeadLetterMessageAsync(msg, "test-reason", "harness-dead-letter");
+        }
+
+        // Now peek the DLQ for this entity.
+        var dlqPath = $"{SessionQueueName}/$deadletterqueue";
+        await using var dlqReceiver = _client.CreateReceiver(dlqPath);
+        ServiceBusReceivedMessage? dl = null;
+        // DLQ may have prior messages; scan for our id.
+        for (int i = 0; i < 10; i++)
+        {
+            var m = await dlqReceiver.ReceiveMessageAsync(TimeSpan.FromSeconds(3));
+            if (m is null) break;
+            if (m.MessageId == messageId) { dl = m; break; }
+            await dlqReceiver.CompleteMessageAsync(m);
+        }
+        Assert.NotNull(dl);
+        Assert.Equal("test-reason", dl.DeadLetterReason);
+        await dlqReceiver.CompleteMessageAsync(dl);
+    }
+
+    [Fact]
+    public async Task SessionMessage_RenewMessageLock_RejectedBySdk()
+    {
+        // The Azure SDK explicitly rejects per-message lock renewal on
+        // session-enabled queues — session locks govern message lifetime.
+        // Calling it must throw InvalidOperationException BEFORE reaching
+        // the broker. Both emulators should exhibit identical behavior
+        // because this is enforced entirely client-side.
+        var sessionId = $"s-{Guid.NewGuid():N}";
+        await using var sender = _client.CreateSender(SessionQueueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("sdk-enforced")
+        { MessageId = Guid.NewGuid().ToString(), SessionId = sessionId });
+
+        await using var receiver = await _client.AcceptSessionAsync(SessionQueueName, sessionId);
+        var msg = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
+        Assert.NotNull(msg);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => receiver.RenewMessageLockAsync(msg));
+        Assert.Contains("session", ex.Message, StringComparison.OrdinalIgnoreCase);
+        _output.WriteLine($"Caught (as expected): {ex.Message}");
+
+        await receiver.CompleteMessageAsync(msg);
+    }
+
+    [Fact]
+    public async Task SessionLock_RenewExtendsExpiryByApproximatelyLockDuration()
+    {
+        // The queue is configured with LockDuration=10s in Config.json (MS) / the
+        // runner script (ours). A successful renewal should push the expiry out
+        // by roughly that amount — we allow a generous tolerance to absorb clock
+        // skew between client and server.
+        var sessionId = $"s-{Guid.NewGuid():N}";
+        await using var sender = _client.CreateSender(SessionQueueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("renewal-size")
+        { MessageId = Guid.NewGuid().ToString(), SessionId = sessionId });
+
+        await using var receiver = await _client.AcceptSessionAsync(SessionQueueName, sessionId);
+        await Task.Delay(500);
+
+        await receiver.RenewSessionLockAsync();
+        var until = receiver.SessionLockedUntil;
+        var delta = until - DateTimeOffset.UtcNow;
+        _output.WriteLine($"Post-renew delta from now: {delta.TotalSeconds:F2}s");
+        // 10s lock, allow [5s, 30s] as a very generous window.
+        Assert.InRange(delta.TotalSeconds, 5.0, 30.0);
+
+        var msg = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
+        if (msg is not null) await receiver.CompleteMessageAsync(msg);
+    }
+}

--- a/tests/ms-emulator-comparison/README.md
+++ b/tests/ms-emulator-comparison/README.md
@@ -1,35 +1,67 @@
 # MS Emulator Comparison
 
-Runs Wolverine's Azure Service Bus tests against Microsoft's official emulator
-to determine if failures are Wolverine bugs or emulator-specific issues.
+Runs identical test scenarios against **both** Microsoft's official Azure Service
+Bus emulator and our AlmostServiceBus emulator, then diffs the results to find
+where we diverge.
 
 ## Prerequisites
 
-- Docker
+- Docker & Docker Compose (for the MS emulator)
 - .NET 10 SDK
-- `socat` (for port forwarding)
+- `socat` (for the Wolverine harness only)
+- `jq`, `curl`, `fuser` (standard POSIX tooling)
 
-## Usage
+## Harnesses
+
+### `run-lock-renewal-comparison.sh` — Lock renewal compatibility
+
+Exercises every lock-renewal path the Azure SDK uses:
+
+| Scenario | Expected |
+|----|----|
+| `MessageLock_RenewExtendsExpiry` | success, LockedUntil advances |
+| `MessageLock_RenewAfterComplete_ThrowsMessageLockLost` | ServiceBusException(MessageLockLost) |
+| `MessageLock_RenewAfterAbandon_ThrowsMessageLockLost` | ServiceBusException(MessageLockLost) |
+| `MessageLock_RenewAfterNaturalExpiry_ThrowsMessageLockLost` | ServiceBusException(MessageLockLost) |
+| `MessageLock_RenewMultipleTimes_Succeeds` | success |
+| `SessionLock_RenewExtendsExpiry` | success |
+| `SessionLock_RenewAfterNaturalExpiry_ThrowsSessionLockLost` | ServiceBusException(SessionLockLost) |
+| `SessionLock_RenewMultipleTimes_Succeeds` | success |
+| `MessageLock_AutoRenewalSurvivesSlowConsumer` | success (SDK auto-renews across 25s processing) |
 
 ```bash
-./run-wolverine-against-ms-emulator.sh
+./run-lock-renewal-comparison.sh
 ```
 
-This will:
-1. Start the MS ASB emulator (Docker containers)
-2. Forward port 5673→5672 (Wolverine expects 5673)
-3. Run the `tracking_correlation_id_on_everything` tests
-4. Run the full Wolverine suite
-5. Clean up
+The script runs the suite twice (once per emulator) and prints a side-by-side
+table plus a divergence list. Exits non-zero if any test outcome differs.
 
-## What we're testing
+Output lives in `comparison-results/` (trx XML + logs).
 
-The `tracking_correlation_id_on_everything` test fails against our emulator
-with a 1-minute timeout. Messages are `Released` by the Azure SDK's
-ServiceBusProcessor instead of being processed. Our standalone tests (14 of
-them) prove the emulator handles batch+processor correctly, so the issue is
-in Wolverine's handler pipeline interaction.
+### `run-wolverine-against-ms-emulator.sh` — Wolverine test compatibility
 
-Running against the MS emulator tells us whether this is:
-- A Wolverine bug (fails on both emulators)
-- An AMQP compatibility issue specific to our AMQPNetLite-based server
+Runs Wolverine's Azure Service Bus tests against the MS emulator to determine if
+Wolverine-test failures are transport-specific or Wolverine bugs. See the
+script for details.
+
+## Why lock-renewal-comparison exists
+
+Under Black Friday load on our emulator we saw `R-DUPE` warnings in MassTransit
+and "session channel N cannot be found" errors on both the server and the SDK
+side. Most of these trace back to lock-renewal corner cases: the emulator
+replying with a fake success when the token is unknown, races between
+`RenewLock` and `SweepExpiredLocks`, or detach-response frames arriving at a
+session the client has already End'd.
+
+Having a deterministic, side-by-side harness lets us catch regressions and
+incrementally close every divergence until we're 1:1 with the official service.
+
+## Adding new scenarios
+
+Add a `[Fact]` to `LockRenewalComparison/LockRenewalTests.cs`. The tests use
+the SDK exclusively and read their connection string from
+`SBE_CONNECTION_STRING`, so no harness changes are needed.
+
+The MS emulator only creates queues listed in
+`LockRenewalComparison/Config.json`, so if you need new entities, add them
+there too.

--- a/tests/ms-emulator-comparison/run-lock-renewal-comparison.sh
+++ b/tests/ms-emulator-comparison/run-lock-renewal-comparison.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# Compare lock-renewal behavior between Microsoft's official ASB emulator and ours.
+#
+# Requirements on the host: Docker (for MS emulator), .NET 10 SDK, jq.
+#
+# Usage:  ./run-lock-renewal-comparison.sh
+#
+# Result: prints per-test pass/fail for each emulator side-by-side. Exits
+# non-zero if any test diverges.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HARNESS_DIR="$SCRIPT_DIR/LockRenewalComparison"
+RESULTS_DIR="$SCRIPT_DIR/comparison-results"
+mkdir -p "$RESULTS_DIR"
+
+run_tests() {
+    local label="$1"
+    local conn="$2"
+    local trx="$RESULTS_DIR/${label}.trx"
+    local log="$RESULTS_DIR/${label}.log"
+
+    echo "=== Running lock-renewal tests against: $label ==="
+    rm -f "$trx"
+    SBE_CONNECTION_STRING="$conn" dotnet test "$HARNESS_DIR" \
+        --no-build \
+        --logger "trx;LogFileName=$trx" \
+        --verbosity normal \
+        > "$log" 2>&1 || true
+    echo "  Log: $log"
+    echo "  Trx: $trx"
+}
+
+summarize() {
+    local label="$1"
+    local trx="$RESULTS_DIR/${label}.trx"
+    if [ ! -f "$trx" ]; then
+        echo "  (no trx file — test run failed to start)"
+        return
+    fi
+    # Extract test results from the trx XML.
+    grep -oP 'outcome="[^"]*"\s+testName="[^"]*"' "$trx" \
+        | sed -E 's/outcome="([^"]+)"\s+testName="[^"]+\.([^"]+)"/\1 \2/' \
+        | sort -u
+}
+
+cd "$REPO_ROOT"
+
+# --- Build the harness once ---
+echo "=== Building harness ==="
+dotnet build "$HARNESS_DIR" --verbosity quiet || {
+    echo "Harness build failed" >&2
+    exit 1
+}
+
+# ------------------------------------------------------------------ MS emulator
+echo ""
+echo "============================================================"
+echo "PHASE 1: Microsoft official ASB emulator (Docker)"
+echo "============================================================"
+
+cd "$SCRIPT_DIR"
+# Copy our Config.json into place so the MS emulator has the queues we need.
+if [ ! -f Config.json ]; then
+    cp "$HARNESS_DIR/Config.json" Config.json
+fi
+
+# Start the MS emulator. Override docker-compose to mount the config file.
+cat > docker-compose.override.yml <<'EOF'
+services:
+  servicebus-emulator:
+    volumes:
+      - ./Config.json:/ServiceBus_Emulator/ConfigFiles/Config.json:ro
+    environment:
+      CONFIG_PATH: /ServiceBus_Emulator/ConfigFiles/Config.json
+EOF
+
+docker compose down -v 2>/dev/null || true
+docker compose up -d
+echo "Waiting for MS emulator to be healthy..."
+MS_READY=0
+for i in $(seq 1 60); do
+    if docker compose exec -T servicebus-emulator curl -sf http://localhost:5300/ > /dev/null 2>&1; then
+        MS_READY=1
+        echo "MS emulator ready!"
+        break
+    fi
+    sleep 2
+done
+
+if [ "$MS_READY" = "1" ]; then
+    # The MS emulator exposes SAS creds as env vars inside the container; the
+    # public documented default is below.
+    MS_CONN="Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true"
+    cd "$REPO_ROOT"
+    run_tests "ms-emulator" "$MS_CONN"
+else
+    echo "WARNING: MS emulator failed to become ready — skipping." >&2
+    echo "(Check 'docker compose logs' in $SCRIPT_DIR for details.)" >&2
+fi
+
+cd "$SCRIPT_DIR"
+docker compose down -v 2>/dev/null || true
+rm -f docker-compose.override.yml Config.json
+
+# ------------------------------------------------------------------ Our emulator
+echo ""
+echo "============================================================"
+echo "PHASE 2: Our AlmostServiceBus emulator"
+echo "============================================================"
+
+# Kill anything on our ports first.
+for port in 5672 5671 5300 443 15672; do
+    fuser -k "$port/tcp" 2>/dev/null || true
+done
+sleep 1
+
+# Start our emulator in the background.
+cd "$REPO_ROOT"
+OUR_LOG="$RESULTS_DIR/our-emulator-runtime.log"
+dotnet run --project src/AlmostServiceBus.Host --no-build > "$OUR_LOG" 2>&1 &
+OUR_PID=$!
+echo "Started emulator (PID $OUR_PID); log: $OUR_LOG"
+
+echo "Waiting for our emulator to be ready..."
+OUR_READY=0
+for i in $(seq 1 30); do
+    if curl -sf http://localhost:5300/ > /dev/null 2>&1 || nc -z localhost 5672 2>/dev/null; then
+        OUR_READY=1
+        echo "Our emulator ready!"
+        break
+    fi
+    sleep 1
+done
+
+if [ "$OUR_READY" = "1" ]; then
+    # Our emulator auto-creates queues via AMQP attach, but we need to be sure
+    # the session queue has RequiresSession=true. Do that via the management
+    # API before running the harness.
+    curl -s -X PUT http://localhost:5300/lock-renewal-queue \
+        -H "Content-Type: application/atom+xml;type=entry;charset=utf-8" \
+        -d '<entry xmlns="http://www.w3.org/2005/Atom"><content type="application/xml"><QueueDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"><LockDuration>PT10S</LockDuration><RequiresSession>false</RequiresSession></QueueDescription></content></entry>' \
+        > /dev/null || true
+
+    curl -s -X PUT http://localhost:5300/session-renewal-queue \
+        -H "Content-Type: application/atom+xml;type=entry;charset=utf-8" \
+        -d '<entry xmlns="http://www.w3.org/2005/Atom"><content type="application/xml"><QueueDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect"><LockDuration>PT10S</LockDuration><RequiresSession>true</RequiresSession></QueueDescription></content></entry>' \
+        > /dev/null || true
+
+    OUR_CONN="Endpoint=sb://localhost:5672;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=emulator"
+    run_tests "our-emulator" "$OUR_CONN"
+else
+    echo "WARNING: Our emulator failed to become ready — skipping." >&2
+fi
+
+kill "$OUR_PID" 2>/dev/null || true
+wait "$OUR_PID" 2>/dev/null || true
+
+# ------------------------------------------------------------------ Compare
+echo ""
+echo "============================================================"
+echo "RESULTS"
+echo "============================================================"
+
+MS_SUMMARY="$RESULTS_DIR/ms-summary.txt"
+OUR_SUMMARY="$RESULTS_DIR/our-summary.txt"
+summarize ms-emulator  > "$MS_SUMMARY"
+summarize our-emulator > "$OUR_SUMMARY"
+
+printf "\n%-60s  %-15s  %-15s\n" "TEST" "MS-EMULATOR" "OURS"
+printf -- "--------------------------------------------------------------------------------------\n"
+
+# Join the two summaries by test name.
+join -j 2 -a 1 -a 2 -e "MISSING" -o '0,1.1,2.1' \
+    <(sort -k2 "$MS_SUMMARY") \
+    <(sort -k2 "$OUR_SUMMARY") \
+    | awk '{ printf "%-60s  %-15s  %-15s\n", $1, $2, $3 }'
+
+# Diff-style summary of divergences.
+echo ""
+echo "============================================================"
+echo "DIVERGENCES (tests where MS and ours disagree)"
+echo "============================================================"
+divergences=$(
+    join -j 2 -a 1 -a 2 -e "MISSING" -o '0,1.1,2.1' \
+        <(sort -k2 "$MS_SUMMARY") \
+        <(sort -k2 "$OUR_SUMMARY") \
+        | awk '$2 != $3 { print }'
+)
+if [ -z "$divergences" ]; then
+    echo "(none — we're 1:1 compatible for lock renewal!)"
+    exit 0
+else
+    echo "$divergences"
+    exit 1
+fi


### PR DESCRIPTION
This pull request introduces several important changes to improve AMQP protocol handling, error reporting, and session/message reliability in the Service Bus implementation. The changes focus on making the system's behavior more closely match Azure Service Bus, reducing message duplication (R-DUPE), and ensuring the SDK receives accurate error signals. Below are the most significant updates grouped by theme:

**AMQP Protocol Handling and State Management:**

* Changed the handling of Detach frames for links in pre-Attached states (`Start`, `AttachSent`) to transition to `DetachSent` instead of `Attached`. This prevents sending a Detach response frame when the client may have already closed the session, avoiding "session channel N cannot be found" errors and unnecessary connection drops. [[1]](diffhunk://#diff-2869b4758c870323caaf179ce43831e3b8c35ff74aa98aed8399fc047c08196eL43-R49) [[2]](diffhunk://#diff-2869b4758c870323caaf179ce43831e3b8c35ff74aa98aed8399fc047c08196eL107-R131) [[3]](diffhunk://#diff-2869b4758c870323caaf179ce43831e3b8c35ff74aa98aed8399fc047c08196eL132-R147)
* Removed the use of `CompleteAttach` and direct state transitions to `Attached` in favor of a consistent move to `DetachSent` for safer Detach handling.

**Error Reporting and SDK Compatibility:**

* Updated error responses for lost message locks and session locks to use status 410 (Gone) with Azure-specific error conditions (`com.microsoft:message-lock-lost`, `com.microsoft:session-lock-lost`). This allows the SDK to recognize and propagate the correct exceptions to consumers, preventing silent failures and unnecessary renew attempts. [[1]](diffhunk://#diff-a3b41d2323fc0b66ba5795aaf92c570f6c308291267e7a05e017c292846f3464L255-R290) [[2]](diffhunk://#diff-a3b41d2323fc0b66ba5795aaf92c570f6c308291267e7a05e017c292846f3464L316-R354)
* Enhanced the `SendErrorResponse` method to include an `errorCondition` property in AMQP responses, matching Azure SDK expectations for error mapping. [[1]](diffhunk://#diff-a3b41d2323fc0b66ba5795aaf92c570f6c308291267e7a05e017c292846f3464L454-R492) [[2]](diffhunk://#diff-a3b41d2323fc0b66ba5795aaf92c570f6c308291267e7a05e017c292846f3464R503-R512)

**Session and Message Reliability:**

* Moved the logic to reclaim pending session messages from session receiver link closure to session acceptance. This eliminates race conditions that could lead to duplicate message delivery (R-DUPE) by ensuring pending messages are only reclaimed when a new receiver safely takes over the session. [[1]](diffhunk://#diff-a5ac6912c95cfa70d852c165d2d3f5c15becae9fbe94e33ce2f9cfeae76ca3aaR263-R289) [[2]](diffhunk://#diff-bf1b2b5b846d81b5994cdaf682edbf152c93d8e2ddd1835f76e42c77663e2b41L186-R200) [[3]](diffhunk://#diff-bf1b2b5b846d81b5994cdaf682edbf152c93d8e2ddd1835f76e42c77663e2b41L202-L216)

**Message Settlement Improvements:**

* Refactored message settlement logic to consistently extract dead-letter reason and description (including SDK-provided fields) for both session and non-session receivers. Also, improved handling of `Modified` states to dead-letter undeliverable messages. [[1]](diffhunk://#diff-d451fbb1216e0fe4de7c7f19d00ecd16c015ce892353d84c06720115c767cc95L208-L216) [[2]](diffhunk://#diff-d451fbb1216e0fe4de7c7f19d00ecd16c015ce892353d84c06720115c767cc95L226-R245) [[3]](diffhunk://#diff-bf1b2b5b846d81b5994cdaf682edbf152c93d8e2ddd1835f76e42c77663e2b41L133-R138)

**Minor Cleanups:**

* Removed an unused `using Amqp.Listener;` directive from `GuidDeliveryTagHandler.cs`.

These changes collectively improve protocol compliance, error transparency, and reliability under load, especially in scenarios involving session receivers and message lock management.