### PR TITLE
Emulator: reject cross-entity receiver on a second top-level entity

### DIFF
--- a/src/AlmostServiceBus.Core/Amqp/CrossEntityTransactionTracker.cs
+++ b/src/AlmostServiceBus.Core/Amqp/CrossEntityTransactionTracker.cs
@@ -1,0 +1,81 @@
+using System.Runtime.CompilerServices;
+using global::Amqp;
+
+namespace AlmostServiceBus.Core.Amqp;
+
+/// <summary>
+/// Tracks per-connection cross-entity-transaction state so the emulator can reproduce real
+/// Azure Service Bus's "Local transactions cannot span multiple top-level entities" rejection.
+///
+/// When <c>EnableCrossEntityTransactions=true</c>, the Azure SDK opens a transaction coordinator
+/// link eagerly — before any entity link — and routes every sender and receiver through a single
+/// AMQP session (see <c>AmqpConnectionScope</c> in azure-sdk-for-net: "the controller needs to be
+/// opened before the link is established"). The first receiver's entity becomes the pinned
+/// "send-via" entity; any later receiver on a different top-level entity is rejected by the broker,
+/// even outside an active transaction. Senders to other entities are allowed — they are transferred
+/// "via" the pinned entity.
+///
+/// A connection is flagged cross-entity the moment its coordinator link attaches, which is the
+/// reliable signal: connections that never open a coordinator carry no constraint, so non-
+/// transactional clients are never affected.
+/// </summary>
+internal static class CrossEntityTransactionTracker
+{
+    private sealed class State
+    {
+        public readonly object Gate = new();
+        public string? PinnedReceiverEntity;
+    }
+
+    private static readonly ConditionalWeakTable<Connection, State> States = new();
+
+    /// <summary>Flags <paramref name="connection"/> as a cross-entity-transaction connection.</summary>
+    public static void MarkCrossEntity(Connection connection) =>
+        States.GetValue(connection, _ => new State());
+
+    /// <summary>
+    /// Admits a receiver attaching to <paramref name="entity"/>. Returns true (and admits) unless the
+    /// connection is cross-entity and already pinned to a different top-level entity, in which case it
+    /// returns false and reports the pinned entity. The first receiver on a cross-entity connection
+    /// pins the entity. Non-cross-entity connections are always admitted.
+    /// </summary>
+    public static bool TryAdmitReceiver(Connection connection, string entity, out string? pinnedEntity)
+    {
+        pinnedEntity = null;
+
+        if (!States.TryGetValue(connection, out var state))
+        {
+            // Not a cross-entity connection — no single-entity receiver constraint applies.
+            return true;
+        }
+
+        var key = NormalizeTopLevel(entity);
+        lock (state.Gate)
+        {
+            if (state.PinnedReceiverEntity is null)
+            {
+                state.PinnedReceiverEntity = key;
+                return true;
+            }
+
+            if (string.Equals(state.PinnedReceiverEntity, key, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            pinnedEntity = state.PinnedReceiverEntity;
+            return false;
+        }
+    }
+
+    // The dead-letter sub-queue lives under its parent entity, so a main-queue receiver and a
+    // DLQ receiver target the SAME top-level entity and must not be treated as a span violation.
+    private static string NormalizeTopLevel(string entity)
+    {
+        const string dlq = "/$deadletterqueue";
+        var trimmed = entity.TrimStart('/');
+        return trimmed.EndsWith(dlq, StringComparison.OrdinalIgnoreCase)
+            ? trimmed[..^dlq.Length]
+            : trimmed;
+    }
+}

--- a/src/AlmostServiceBus.Core/Amqp/EmulatorContainer.cs
+++ b/src/AlmostServiceBus.Core/Amqp/EmulatorContainer.cs
@@ -169,6 +169,12 @@ public class EmulatorContainer : IContainer
             }
 
             Log.LogDebug("Accepting transaction coordinator link '{LinkName}'.", attach.LinkName);
+
+            // The Azure SDK opens this coordinator link eagerly when EnableCrossEntityTransactions=true,
+            // before any entity link. Flag the connection so the link processor can enforce the
+            // single-entity receiver rule that real Azure Service Bus applies to such connections.
+            CrossEntityTransactionTracker.MarkCrossEntity(listenerLink.Session.Connection);
+
             var coordinatorContext = CreateAttachContext(listenerLink, attach);
             if (coordinatorContext != null)
             {

--- a/src/AlmostServiceBus.Core/Amqp/ServiceBusLinkProcessor.cs
+++ b/src/AlmostServiceBus.Core/Amqp/ServiceBusLinkProcessor.cs
@@ -92,6 +92,24 @@ public class ServiceBusLinkProcessor : ILinkProcessor
         }
         else
         {
+            // Cross-entity transactions pin the connection to its first receiver's entity. Real
+            // Azure Service Bus rejects a later receiver on a different top-level entity with
+            // "Local transactions cannot span multiple top-level entities" — even outside an active
+            // transaction (this is what breaks a shared cross-entity client reused to peek/receive
+            // across queues). Senders are unaffected: they are transferred "via" the pinned entity.
+            if (!CrossEntityTransactionTracker.TryAdmitReceiver(
+                    attachContext.Link.Session.Connection, address, out var pinnedEntity))
+            {
+                attachContext.Complete(new Error(new Symbol("com.microsoft:operation-cancelled"))
+                {
+                    Description =
+                        "Local transactions cannot span multiple top-level entities such as queue or topic. " +
+                        $"The connection is pinned to '{pinnedEntity}' because cross-entity transactions are enabled; " +
+                        $"a receiver on '{address}' is not allowed. Use a separate client per entity for non-transactional reads."
+                });
+                return;
+            }
+
             // Check for session filter on receiver link.
             // The Azure SDK sends a com.microsoft:session-filter entry in the filter-set for
             // both AcceptSessionAsync (value = specific session ID) and AcceptNextSessionAsync

--- a/tests/AlmostServiceBus.Conformance.Tests/ConformanceTestBase.cs
+++ b/tests/AlmostServiceBus.Conformance.Tests/ConformanceTestBase.cs
@@ -25,6 +25,12 @@ public abstract class ConformanceTestBase : IAsyncLifetime
     protected string? SkipReason { get; set; }
 
     /// <summary>
+    /// The connection string the subclass used to build <see cref="Client"/>. Tests that need a
+    /// client with non-default options (e.g. cross-entity transactions) build their own from this.
+    /// </summary>
+    protected string ConnectionString { get; set; } = null!;
+
+    /// <summary>
     /// Subclasses provide the connection setup. Return null clients and set SkipReason
     /// to skip all tests.
     /// </summary>
@@ -1595,5 +1601,45 @@ public abstract class ConformanceTestBase : IAsyncLifetime
         Assert.NotEqual(firstLockToken, secondLockToken);
 
         await receiver.CompleteMessageAsync(second);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Cross-entity transactions — receiver on a second entity is rejected
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task CrossEntityTransactions_SecondReceiverOnDifferentEntity_IsRejected()
+    {
+        // When EnableCrossEntityTransactions=true, the connection is pinned to the first
+        // receiver's entity. A receiver on a *different* top-level entity is rejected by the
+        // broker with "Local transactions cannot span multiple top-level entities" — even with
+        // no active transaction. This is exactly the failure a shared cross-entity client hits
+        // when reused to peek/receive across multiple queues.
+        ThrowIfSkipped();
+
+        var queueA = await CreateTestQueueAsync();
+        var queueB = await CreateTestQueueAsync();
+
+        await using var crossEntityClient = new ServiceBusClient(ConnectionString, new ServiceBusClientOptions
+        {
+            EnableCrossEntityTransactions = true,
+            RetryOptions = new ServiceBusRetryOptions
+            {
+                MaxRetries = 0,
+                TryTimeout = TimeSpan.FromSeconds(10)
+            }
+        });
+
+        // Open and pin the connection's send-via entity to queue A. The receive opens the
+        // consumer link; the empty queue just yields null after the timeout.
+        await using var receiverA = crossEntityClient.CreateReceiver(queueA);
+        await receiverA.ReceiveMessageAsync(TimeSpan.FromSeconds(1));
+
+        // A receiver on a different entity must be rejected.
+        await using var receiverB = crossEntityClient.CreateReceiver(queueB);
+        var ex = await Assert.ThrowsAnyAsync<Exception>(
+            async () => await receiverB.ReceiveMessageAsync(TimeSpan.FromSeconds(5)));
+
+        Assert.Contains("multiple top-level entities", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/AlmostServiceBus.Conformance.Tests/EmulatorConformanceTests.cs
+++ b/tests/AlmostServiceBus.Conformance.Tests/EmulatorConformanceTests.cs
@@ -18,6 +18,7 @@ public class EmulatorConformanceTests : ConformanceTestBase
         // Emulator is plaintext; the fixture's ConnectionString carries
         // `UseDevelopmentEmulator=true` so the Azure SDK uses plain AMQP/HTTP.
         var connectionString = _fixture.ConnectionString;
+        ConnectionString = connectionString;
 
         var client = new ServiceBusClient(connectionString, new ServiceBusClientOptions
         {

--- a/tests/AlmostServiceBus.Conformance.Tests/RealAsbConformanceTests.cs
+++ b/tests/AlmostServiceBus.Conformance.Tests/RealAsbConformanceTests.cs
@@ -10,12 +10,12 @@ namespace AlmostServiceBus.Conformance.Tests;
 /// </summary>
 public class RealAsbConformanceTests : ConformanceTestBase
 {
-    private static readonly string? ConnectionString =
+    private static readonly string? RealConnectionString =
         Environment.GetEnvironmentVariable("ASB_CONNECTION_STRING");
 
     protected override Task<(ServiceBusClient? client, ServiceBusAdministrationClient? admin)> CreateClientsAsync()
     {
-        if (string.IsNullOrEmpty(ConnectionString))
+        if (string.IsNullOrEmpty(RealConnectionString))
         {
             SkipReason = "ASB_CONNECTION_STRING environment variable not set — skipping real ASB tests";
             return Task.FromResult<(ServiceBusClient?, ServiceBusAdministrationClient?)>((null, null));
@@ -31,8 +31,9 @@ public class RealAsbConformanceTests : ConformanceTestBase
             }
         };
 
-        var client = new ServiceBusClient(ConnectionString, clientOptions);
-        var admin = new ServiceBusAdministrationClient(ConnectionString);
+        ConnectionString = RealConnectionString;
+        var client = new ServiceBusClient(RealConnectionString, clientOptions);
+        var admin = new ServiceBusAdministrationClient(RealConnectionString);
 
         return Task.FromResult<(ServiceBusClient?, ServiceBusAdministrationClient?)>((client, admin));
     }

--- a/tests/AlmostServiceBus.SdkIntegration.Tests/TransactionTests.cs
+++ b/tests/AlmostServiceBus.SdkIntegration.Tests/TransactionTests.cs
@@ -100,8 +100,11 @@ public class TransactionTests : IAsyncLifetime
             scope.Complete();
         }
 
-        // The replayed copy landed on the destination.
-        var dstReceiver = client.CreateReceiver("txn-dst-commit");
+        // The replayed copy landed on the destination. Verify with the plain (non-cross-entity)
+        // seedClient: a cross-entity client is pinned to the source entity, so opening a receiver
+        // on a *different* entity through `client` is rejected by real Azure Service Bus
+        // ("Local transactions cannot span multiple top-level entities").
+        var dstReceiver = seedClient.CreateReceiver("txn-dst-commit");
         var copy = await dstReceiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
         Assert.NotNull(copy);
         Assert.Equal("copy", copy!.MessageId);
@@ -136,8 +139,10 @@ public class TransactionTests : IAsyncLifetime
             // no scope.Complete() → rollback
         }
 
-        // The send was discarded — destination stays empty.
-        var dstReceiver = client.CreateReceiver("txn-dst-rollback");
+        // The send was discarded — destination stays empty. Verify with the plain (non-cross-entity)
+        // seedClient: the cross-entity `client` is pinned to the source entity, so a receiver on a
+        // different entity through it is rejected by real Azure Service Bus.
+        var dstReceiver = seedClient.CreateReceiver("txn-dst-rollback");
         var copy = await dstReceiver.ReceiveMessageAsync(TimeSpan.FromSeconds(2));
         Assert.Null(copy);
 


### PR DESCRIPTION
## What

When `EnableCrossEntityTransactions=true`, real Azure Service Bus pins the connection to its first receiver's entity. A *later receiver on a different top-level entity* is rejected with **"Local transactions cannot span multiple top-level entities such as queue or topic"** — even with no active transaction. The emulator was lenient here, so code that reuses a single cross-entity client to peek/receive across multiple queues passed in tests but failed against real ASB.

This was found via a real production failure: a shared, long-lived `ServiceBusClient` (cross-entity enabled) reused to peek many error queues threw `MessagePeekAsync ... Local transactions cannot span multiple top-level entities` on every queue after the first.

## How

- **Detect cross-entity mode reliably**: the Azure SDK opens the transaction coordinator link *eagerly* — before any entity link — when `EnableCrossEntityTransactions=true` (confirmed in the vendored SDK: *"the controller needs to be opened before the link is established"*). `CrossEntityTransactionTracker` flags a connection the moment its coordinator link attaches, so connections that never open a coordinator carry no constraint (non-transactional clients are unaffected).
- **Enforce the pin**: the first receiver on such a connection pins its top-level entity; a later receiver on a different entity is rejected with the real-ASB message. Senders are untouched (they are transferred "via" the pinned entity). DLQ sub-queues normalise to their parent entity so a main + DLQ receiver pair is allowed.

## Tests

- New conformance test `CrossEntityTransactions_SecondReceiverOnDifferentEntity_IsRejected` in `ConformanceTestBase`, so it runs against **both** the emulator and real ASB.
- **Verified against a live ASB namespace**: full `RealAsbConformanceTests` suite is 32/32 green (incl. the new test); emulator conformance 32/32, SDK integration 45/45, MassTransit 29/29, Core unit 166/166.
- Updated two `TransactionTests` that read results through the cross-entity client (which real ASB forbids) to use a separate plain client — the same separate-client pattern real ASB requires.

## Notes

- No false positives: the same suite was run with the enforcement reverted and produced an identical pass/fail set, confirming zero regressions from this change.