### PR TITLE
Enable Dependabot for NuGet and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Dependabot version updates. NuGet discovery from "/" recurses through src/, tests/
+# and samples/; the external/* git submodules (azure-sdk-for-net, MassTransit, etc.)
+# are separate repos and are not scanned.
+#
+# Note: this file enables *version* updates only. Dependabot security updates and
+# vulnerability alerts (e.g. the MessagePack advisory) are toggled in the repo's
+# Settings → Code security, not here.
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      # Roll routine minor/patch bumps into a single weekly PR to cut noise;
+      # major bumps still come through as their own PRs for individual review.
+      nuget-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` to enable weekly Dependabot **version updates** for:

- **NuGet** — discovery from `/` recurses through `src/`, `tests/` and `samples/`. The `external/*` git submodules (azure-sdk-for-net, MassTransit, wolverine, NServiceBus.Transport.AzureServiceBus) are separate repos and are not scanned.
- **GitHub Actions** — keeps `ci.yml` actions current.

Minor/patch bumps are grouped into a single weekly PR to cut noise; major bumps come through as individual PRs for review.

## Why

Keep dependencies current — e.g. `MessagePack`, which currently trips `NU1903` (known high-severity advisory) in `AlmostServiceBus.Aspire.Hosting`.

## Follow-up (repo setting, not in this PR)

`dependabot.yml` enables *version* updates only. **Dependabot security updates** and **vulnerability alerts** are a repo setting (Settings → Code security), and that's what directly drives advisory-based bumps like the MessagePack one. Worth enabling alongside this.