### PR TITLE
Enable Renovate for dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "ignorePaths": [
+    "external/**"
+  ],
+  "nuget": {
+    "enabled": true
+  },
+  "github-actions": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
## What

Adds `renovate.json` to enable [Renovate](https://docs.renovatebot.com/) dependency updates:

- Extends `config:recommended` (sensible defaults: grouping, major updates separated, dependency dashboard).
- **NuGet** and **GitHub Actions** managers enabled — covers `src/`, `tests/`, `samples/` and `ci.yml`.
- `external/*` git submodules excluded via `ignorePaths` (they're separate repos).
- Validated locally with `renovate-config-validator` ✓.

## Why

Keep dependencies current — e.g. `MessagePack`, which currently trips `NU1903` (known high-severity advisory) pulled transitively into `AlmostServiceBus.Aspire.Hosting`.

## Requirements / follow-ups

- **Renovate App**: requires the [Mend Renovate GitHub App](https://github.com/apps/renovate) to be installed on the repo/org for the config to run. (If self-hosting Renovate via Actions instead, that's a separate workflow.)
- **MessagePack is transitive** (no direct `PackageReference`). Renovate version updates target direct deps, so the advisory may need either Renovate's vulnerability remediation (which reads GitHub security alerts — enable Dependabot alerts in Settings → Code security to feed it) or a direct pin to a fixed MessagePack version. Happy to add the pin in a follow-up.