### PR TITLE
Update outdated dependencies (one per commit) + resolve MessagePack advisory

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/AlmostServiceBus.Aspire.Hosting/AlmostServiceBus.Aspire.Hosting.csproj
+++ b/src/AlmostServiceBus.Aspire.Hosting/AlmostServiceBus.Aspire.Hosting.csproj
@@ -4,14 +4,12 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!-- NU1902: transitive KubernetesClient vulnerability from Aspire.Hosting -->
-    <NoWarn>$(NoWarn);NU1902</NoWarn>
     <!-- Path where Host publish output lands before being packed -->
     <HostPublishDir>$(MSBuildThisFileDirectory)obj\host-publish\</HostPublishDir>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" Version="9.2.1" />
+    <PackageReference Include="Aspire.Hosting" Version="13.4.6" />
     <!-- Build the Host project before this one, but don't reference its assembly -->
     <ProjectReference Include="..\AlmostServiceBus.Host\AlmostServiceBus.Host.csproj"
                       ReferenceOutputAssembly="false"

--- a/src/AlmostServiceBus.Core/AlmostServiceBus.Core.csproj
+++ b/src/AlmostServiceBus.Core/AlmostServiceBus.Core.csproj
@@ -9,7 +9,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AMQPNetLite" Version="2.5.1" />
+    <PackageReference Include="AMQPNetLite" Version="2.5.3" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="AlmostServiceBus.Tests" />

--- a/tests/AlmostServiceBus.Conformance.Tests/AlmostServiceBus.Conformance.Tests.csproj
+++ b/tests/AlmostServiceBus.Conformance.Tests/AlmostServiceBus.Conformance.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AlmostServiceBus.Conformance.Tests/AlmostServiceBus.Conformance.Tests.csproj
+++ b/tests/AlmostServiceBus.Conformance.Tests/AlmostServiceBus.Conformance.Tests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/tests/AlmostServiceBus.Conformance.Tests/AlmostServiceBus.Conformance.Tests.csproj
+++ b/tests/AlmostServiceBus.Conformance.Tests/AlmostServiceBus.Conformance.Tests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/tests/AlmostServiceBus.MassTransit.Tests/AlmostServiceBus.MassTransit.Tests.csproj
+++ b/tests/AlmostServiceBus.MassTransit.Tests/AlmostServiceBus.MassTransit.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AMQPNetLite" Version="2.5.1" />
+    <PackageReference Include="AMQPNetLite" Version="2.5.3" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="MassTransit.Azure.ServiceBus.Core" Version="9.1.0" />

--- a/tests/AlmostServiceBus.MassTransit.Tests/AlmostServiceBus.MassTransit.Tests.csproj
+++ b/tests/AlmostServiceBus.MassTransit.Tests/AlmostServiceBus.MassTransit.Tests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="AMQPNetLite" Version="2.5.3" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="MassTransit.Azure.ServiceBus.Core" Version="9.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/AlmostServiceBus.MassTransit.Tests/AlmostServiceBus.MassTransit.Tests.csproj
+++ b/tests/AlmostServiceBus.MassTransit.Tests/AlmostServiceBus.MassTransit.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="MassTransit.Azure.ServiceBus.Core" Version="9.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AlmostServiceBus.MassTransit.Tests/AlmostServiceBus.MassTransit.Tests.csproj
+++ b/tests/AlmostServiceBus.MassTransit.Tests/AlmostServiceBus.MassTransit.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="AMQPNetLite" Version="2.5.3" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="MassTransit.Azure.ServiceBus.Core" Version="9.1.0" />
+    <PackageReference Include="MassTransit.Azure.ServiceBus.Core" Version="9.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/tests/AlmostServiceBus.MassTransit.Tests/AlmostServiceBus.MassTransit.Tests.csproj
+++ b/tests/AlmostServiceBus.MassTransit.Tests/AlmostServiceBus.MassTransit.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="MassTransit.Azure.ServiceBus.Core" Version="9.1.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/tests/AlmostServiceBus.SdkIntegration.Tests/AlmostServiceBus.SdkIntegration.Tests.csproj
+++ b/tests/AlmostServiceBus.SdkIntegration.Tests/AlmostServiceBus.SdkIntegration.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AlmostServiceBus.SdkIntegration.Tests/AlmostServiceBus.SdkIntegration.Tests.csproj
+++ b/tests/AlmostServiceBus.SdkIntegration.Tests/AlmostServiceBus.SdkIntegration.Tests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AMQPNetLite" Version="2.5.1" />
+    <PackageReference Include="AMQPNetLite" Version="2.5.3" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />

--- a/tests/AlmostServiceBus.SdkIntegration.Tests/AlmostServiceBus.SdkIntegration.Tests.csproj
+++ b/tests/AlmostServiceBus.SdkIntegration.Tests/AlmostServiceBus.SdkIntegration.Tests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="AMQPNetLite" Version="2.5.3" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/tests/AlmostServiceBus.SdkIntegration.Tests/AlmostServiceBus.SdkIntegration.Tests.csproj
+++ b/tests/AlmostServiceBus.SdkIntegration.Tests/AlmostServiceBus.SdkIntegration.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="AMQPNetLite" Version="2.5.3" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/tests/AlmostServiceBus.SdkLive.Tests/AlmostServiceBus.SdkLive.Tests.csproj
+++ b/tests/AlmostServiceBus.SdkLive.Tests/AlmostServiceBus.SdkLive.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AlmostServiceBus.SdkLive.Tests/AlmostServiceBus.SdkLive.Tests.csproj
+++ b/tests/AlmostServiceBus.SdkLive.Tests/AlmostServiceBus.SdkLive.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/tests/AlmostServiceBus.SdkLive.Tests/AlmostServiceBus.SdkLive.Tests.csproj
+++ b/tests/AlmostServiceBus.SdkLive.Tests/AlmostServiceBus.SdkLive.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/tests/AlmostServiceBus.Tests/AlmostServiceBus.Tests.csproj
+++ b/tests/AlmostServiceBus.Tests/AlmostServiceBus.Tests.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/AlmostServiceBus.Tests/AlmostServiceBus.Tests.csproj
+++ b/tests/AlmostServiceBus.Tests/AlmostServiceBus.Tests.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/tests/AlmostServiceBus.Tests/AlmostServiceBus.Tests.csproj
+++ b/tests/AlmostServiceBus.Tests/AlmostServiceBus.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AlmostServiceBus.Tests/AlmostServiceBus.Tests.csproj
+++ b/tests/AlmostServiceBus.Tests/AlmostServiceBus.Tests.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />


### PR DESCRIPTION
## What

Brings all outdated solution dependencies current, **one package per commit**, each built and tested before committing. Headline: the `Aspire.Hosting` bump pulls a fixed transitive `MessagePack`, clearing the high-severity `NU1903` advisory that was breaking the build.

| Commit | Package | Change | Type |
|---|---|---|---|
| `bf6da6f` | AMQPNetLite | 2.5.1 → 2.5.3 | patch (core AMQP lib) |
| `30c7bf4` | MassTransit.Azure.ServiceBus.Core | 9.1.0 → 9.1.2 | patch |
| `2ed20f5` | Microsoft.AspNetCore.TestHost | 10.0.5 → 10.0.9 | patch |
| `3671de9` | xunit.runner.visualstudio | 3.1.4 → 3.1.5 | patch |
| `6f7fc7f` | Microsoft.NET.Test.Sdk | 17.14.1 → 18.7.0 | major |
| `b5f6983` | coverlet.collector | 6.0.4 → 10.0.1 | major |
| `75b9186` | MinVer | 6.0.0 → 7.0.0 | major |
| `55b727d` | Aspire.Hosting | 9.2.1 → 13.4.6 | **major (9→13)** |

## Security

- **MessagePack `NU1903`** (GHSA-hv8m-jj95-wg3x / GHSA-vh6j-jc39-fggf) — resolved via the Aspire.Hosting upgrade. The solution now builds with NuGet audit **enabled**, and `dotnet list package --vulnerable --include-transitive` reports **no vulnerable packages** across all 9 projects.
- Removed a now-stale `NoWarn` for `NU1902` (KubernetesClient) in `Aspire.Hosting` — Aspire 13 no longer pulls the vulnerable version.

## Verification

Each commit built + ran targeted tests. Final run with **all** updates applied (audit on):

- Build: clean (0 warnings/0 errors)
- Unit: **166**, SDK integration: **45**, emulator conformance: **31**, MassTransit: **29**
- **Real Azure Service Bus** conformance: **31/31** green

No API breaks from the Aspire 9→13 major. The Aspire 13 bump built with no source changes needed.

## Out of scope

Projects outside `AlmostServiceBus.sln` were left untouched: the `samples/OrderFlowDemo` apps (still on MassTransit 8.5.3) and `tests/ms-emulator-comparison`. Happy to update those separately if wanted.