### PR TITLE
Stabilize flaky MassTransit bulk test on CI

### DIFF
--- a/tests/AlmostServiceBus.MassTransit.Tests/MassTransitBulkMessageTests.cs
+++ b/tests/AlmostServiceBus.MassTransit.Tests/MassTransitBulkMessageTests.cs
@@ -29,8 +29,12 @@ public class BulkTestConsumer : IConsumer<BulkTestMessage>
 
 public class MassTransitBulkMessageTests : IAsyncLifetime
 {
-    private const int TotalMessages = 1000;
-    private const int FailureRate = 10; // index % 10 == 0 → fail → 100 failures
+    // Kept modest so the test drains reliably even when CI runs several test assemblies
+    // concurrently on a 2-core runner (MaxCpuCount=3). At 1000 it intermittently timed out on
+    // CI — starved of CPU it consumed only ~half before the deadline — while finishing in
+    // seconds locally. 500 still exercises bulk/concurrent behaviour with comfortable headroom.
+    private const int TotalMessages = 500;
+    private const int FailureRate = 10; // index % 10 == 0 → fail → TotalMessages/10 failures
 
     // UseDevelopmentEmulator=true hardcodes AMQP to port 5672, so we must use that port.
     private readonly ServiceBusEmulatorFixture _fixture = new(publicPort: 5672);
@@ -92,7 +96,7 @@ public class MassTransitBulkMessageTests : IAsyncLifetime
         var expectedSuccessCount = 0;
         var expectedFailureCount = 0;
 
-        // Send 1000 messages — 10% will fail deterministically
+        // Send the batch — 10% will fail deterministically
         var sendEndpoint = await _bus.GetSendEndpoint(new Uri($"queue:{_queueName}"));
 
         for (var i = 0; i < TotalMessages; i++)
@@ -103,12 +107,14 @@ public class MassTransitBulkMessageTests : IAsyncLifetime
             await sendEndpoint.Send(new BulkTestMessage(i));
         }
 
-        Assert.Equal(900, expectedSuccessCount);
-        Assert.Equal(100, expectedFailureCount);
+        Assert.Equal(TotalMessages / FailureRate, expectedFailureCount);
+        Assert.Equal(TotalMessages - TotalMessages / FailureRate, expectedSuccessCount);
 
         // Wait for all messages to be consumed + errors to land.
         // MassTransit moves faulted messages to _error queue after retries exhausted.
-        var deadline = DateTime.UtcNow.AddSeconds(120);
+        // Generous deadline for contended CI runners; the loop breaks early once the targets
+        // are met, so a healthy run still finishes in seconds.
+        var deadline = DateTime.UtcNow.AddSeconds(240);
         while (DateTime.UtcNow < deadline)
         {
             var consumed = BulkTestConsumer.Consumed.Count;
@@ -143,7 +149,7 @@ public class MassTransitBulkMessageTests : IAsyncLifetime
         // All messages should be settled (none left in the queue)
         Assert.Equal(0, queue!.MessageCount);
 
-        // All 1000 messages were settled from the source queue — MassTransit accepts
+        // Every message was settled from the source queue — MassTransit accepts
         // even faulted messages, then sends a copy to the _error queue.
         Assert.Equal(TotalMessages, queue.ConsumedCount);
 


### PR DESCRIPTION
## Problem

`MassTransitBulkMessageTests.BulkSend_WithDeterministicFailures_CorrectBrokerState` intermittently fails on CI:

```
Assert.Equal() Failure: Expected 900, Actual 462
```

It consumes only part of the 900 success messages before the 120s deadline.

## Diagnosis — flaky, not a regression

- Locally the test passes in **~6s**; on CI it hit the full 120s deadline at 462.
- The **identical code passed** on the `cross-entity-transaction-strictness` branch run, then failed on the merge-to-main run minutes later — and **passed again on re-run**. Same code, different outcome = timing/contention flake.
- Root cause: CI runs up to **3 test assemblies concurrently** (`MaxCpuCount=3` in `AlmostServiceBus.runsettings`) on a 2-core `ubuntu-latest`, starving this throughput-heavy test of CPU so it can't drain 1000 messages in time.

## Fix

- `TotalMessages` 1000 → **500** (halves the load; still exercises bulk/concurrent behaviour).
- Drain deadline 120s → **240s** — the wait loop already breaks early when targets are met, so healthy runs still finish in seconds; the larger budget only matters under contention.
- Sanity asserts now derive from `TotalMessages` instead of hardcoding 900/100.

Passes locally in ~6s.