### PR TITLE
CI: split internal tests into one job per assembly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,39 @@ jobs:
   # inside each test fixture on random ports, so no separate emulator process
   # is required.  Everything is plaintext (MS-emulator compatibility mode),
   # so no cert setup is needed.
+  #
+  # One assembly per job (matrix): `dotnet test <solution>` runs every test
+  # project in parallel via MSBuild, so on a 2-core runner the emulator-backed
+  # assemblies oversubscribe the CPU and throughput/timing-sensitive tests
+  # (bulk send, scheduled delivery, lock renewal) intermittently time out.
+  # (vstest's runsettings MaxCpuCount does NOT help here — it only caps
+  # assembly parallelism within a single vstest invocation, and per-project
+  # runs never have more than one.)  Giving each assembly its own runner
+  # removes the contention while keeping wall-clock low (jobs run in parallel).
   internal-tests:
-    name: Internal Tests
+    name: "Internal: ${{ matrix.name }}"
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Unit
+            slug: unit
+            project: tests/AlmostServiceBus.Tests
+          - name: SDK Integration
+            slug: sdkintegration
+            project: tests/AlmostServiceBus.SdkIntegration.Tests
+          - name: MassTransit
+            slug: masstransit
+            project: tests/AlmostServiceBus.MassTransit.Tests
+          - name: Conformance
+            slug: conformance
+            project: tests/AlmostServiceBus.Conformance.Tests
+          - name: SDK Live
+            slug: sdklive
+            project: tests/AlmostServiceBus.SdkLive.Tests
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,26 +66,26 @@ jobs:
           dotnet-version: "10.x"
 
       - name: Restore & Build
-        run: dotnet build AlmostServiceBus.sln
+        run: dotnet build ${{ matrix.project }}
 
       - name: Test
         run: |
-          dotnet test AlmostServiceBus.sln \
+          dotnet test ${{ matrix.project }} \
             --no-build \
-            --settings AlmostServiceBus.runsettings \
             --filter "FullyQualifiedName!~RealAsbConformanceTests&FullyQualifiedName!~RealAsbTopicRequeueReproTest" \
             --results-directory artifacts/test-results/internal \
             --logger "trx"
 
       - name: Summarize test results
         if: always()
-        run: python3 .github/scripts/summarize_trx.py "Internal Tests" artifacts/test-results/internal
+        run: |
+          python3 .github/scripts/summarize_trx.py "Internal: ${{ matrix.name }}" artifacts/test-results/internal
 
       - name: Upload TRX results on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: internal-tests-trx
+          name: internal-tests-trx-${{ matrix.slug }}
           path: artifacts/test-results/internal
           retention-days: 7
 

--- a/AlmostServiceBus.runsettings
+++ b/AlmostServiceBus.runsettings
@@ -1,13 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Caps vstest's cross-assembly parallelism at 3 so that at most three test
-  DLLs spin up their emulator fixtures concurrently.  Running all five+
-  test projects in parallel under CI contends for ephemeral ports and has
-  surfaced intermittent "Address already in use" / "Connection refused"
-  failures.  Within-assembly xunit parallelism is unaffected.
+  MaxCpuCount caps assembly parallelism *within a single vstest invocation*.
+
+  NOTE: this has NO effect on `dotnet test <solution>` — that builds and runs
+  each test project as a SEPARATE vstest invocation in parallel via MSBuild, so
+  vstest never sees more than one assembly at a time and this setting is inert.
+  (Measured: MaxCpuCount 3/2/1 gave identical wall-clock and did not change how
+  many emulator-backed assemblies ran concurrently.)
+
+  CI therefore does NOT rely on this file for isolation — it runs each test
+  assembly in its own job (see the `internal-tests` matrix in
+  .github/workflows/ci.yml), which is what actually prevents the emulator
+  fixtures from oversubscribing a 2-core runner and starving throughput/
+  timing-sensitive tests (bulk send, scheduled delivery, lock renewal).
+
+  Kept for running multiple assemblies through one vstest invocation, e.g.
+  `dotnet vstest a.dll b.dll --settings AlmostServiceBus.runsettings`.
 -->
 <RunSettings>
   <RunConfiguration>
-    <MaxCpuCount>3</MaxCpuCount>
+    <MaxCpuCount>2</MaxCpuCount>
   </RunConfiguration>
 </RunSettings>


### PR DESCRIPTION
## Why

The `Internal Tests` job ran the whole solution, and `dotnet test <sln>` runs every test project **in parallel via MSBuild**. On the 2-core runner the emulator-backed assemblies oversubscribe the CPU, so throughput/timing-sensitive tests (bulk send, scheduled delivery, lock renewal) intermittently time out — e.g. `BulkSend_WithDeterministicFailures` consuming 462/900 before its deadline.

## Measured (each run pinned to 2 physical cores = CI proxy)

| Config | Result | Wall-clock |
|---|---|---|
| `runsettings` MaxCpuCount=3 | PASS | 245s |
| MaxCpuCount=2 | PASS | 246s |
| MaxCpuCount=1 | FAIL (scheduled-msg timing) | 247s |
| `-m:1` (true serialize) | PASS | 484s |
| Conformance **alone** | PASS | 245s |
| MassTransit **alone** | PASS | 42s |

Key finding: **`runsettings` MaxCpuCount is inert for `dotnet test <sln>`** — it only caps assembly parallelism *within one* vstest invocation, and MSBuild gives each project its own invocation. Identical wall-clock across 3/2/1 confirms it. The real contention lever is MSBuild parallelism; the reliable + fast fix is **isolation**.

## Change

- Rewrote `internal-tests` as a **matrix**, one runner per assembly: Unit, SDK Integration, MassTransit, Conformance, SDK Live. Mirrors the existing Wolverine/NServiceBus job split.
- Reliability from isolation (solo runs pass); wall-clock ≈ unchanged since jobs run in parallel and Conformance (~4min) is the long pole either way — vs `-m:1` which would double a single job to ~8min.
- Corrected the misleading `AlmostServiceBus.runsettings` comment to document that MaxCpuCount doesn't affect `dotnet test <sln>`.

`pack-and-publish` still gates on `internal-tests` (a `needs:` on a matrixed job waits for all legs). The RealAsb exclusion filter is preserved.