### PR TITLE
Renovate: auto-merge non-major updates when CI is green

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,5 +11,18 @@
   },
   "github-actions": {
     "enabled": true
-  }
+  },
+  "platformAutomerge": false,
+  "packageRules": [
+    {
+      "description": "Auto-merge non-major updates once CI is green; majors stay manual for review.",
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest",
+        "pin"
+      ],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
## What

Adds automerge to `renovate.json`:

- **Auto-merges** minor / patch / digest / pin updates **once the branch's CI checks pass**.
- **Majors stay manual** (opened as PRs for review) — e.g. an Aspire 9→13-style jump.

## How "only when CI is green" is enforced

Uses **Renovate-managed** automerge (`platformAutomerge: false`): Renovate merges a branch only after it observes all its status checks/CI passing. This works **without** branch-protection setup.

- Alternative: if you later add branch protection with the CI checks marked *required* + enable "Allow auto-merge" in repo settings, flip `platformAutomerge` back to `true` to use GitHub-native auto-merge (faster, merges the instant required checks pass). Left off for now so it works out of the box.

Requires the Renovate GitHub App to have write access (it does, once installed).