### PR TITLE
Renovate: switch to GitHub-native auto-merge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "github-actions": {
     "enabled": true
   },
-  "platformAutomerge": false,
+  "platformAutomerge": true,
   "packageRules": [
     {
       "description": "Auto-merge non-major updates once CI is green; majors stay manual for review.",


### PR DESCRIPTION
## Why

Green, mergeable non-major Renovate PRs were sitting unmerged. Root cause: `platformAutomerge: false` makes **Renovate** perform the merge, but only **during a Renovate run** — and the hosted app runs infrequently (last run was ~12h before these PRs went green), so they waited.

The repo already has a **"Main" ruleset** requiring all test jobs (Internal Tests, Wolverine ×3, NServiceBus, MassTransit Conformance) with require-up-to-date-branches. GitHub-native auto-merge **respects those required checks** and merges the moment they pass, regardless of Renovate's cadence — which is exactly "all tests pass, then merge."

## Change

- `platformAutomerge: true` (was `false`).
- Paired with enabling **"Allow auto-merge"** on the repo (done via API — required for GitHub-native auto-merge).

Non-major updates still auto-merge; majors stay manual (unchanged).

## ⚠️ Follow-up needed for the CI-split PR (#46)

The ruleset requires a check named **"Internal Tests"**. PR #46 renames it to `Internal: Unit / SDK Integration / MassTransit / Conformance / SDK Live`. Merging #46 must be paired with updating the ruleset's required contexts to those 5 names, or all PRs will be blocked on the now-missing "Internal Tests" check.