### PR TITLE
Accept the Python azure-servicebus client, and stop dropping the Aspire --Port value

### DIFF
--- a/src/AlmostServiceBus.Aspire.Hosting/AlmostServiceBusBuilderExtensions.cs
+++ b/src/AlmostServiceBus.Aspire.Hosting/AlmostServiceBusBuilderExtensions.cs
@@ -35,11 +35,14 @@ public static class AlmostServiceBusBuilderExtensions
 
         var resource = new AlmostServiceBusResource(name, Path.GetDirectoryName(hostDll)!, dashboardPort);
 
+        // No --no-launch-profile here. That is a `dotnet run` flag; `dotnet exec` hands it to the
+        // Host, whose command-line parser pairs it with the "--Port" that follows and drops the
+        // port value. The Host then listened on its default port while the connection string
+        // advertised the requested one, so a non-default port never worked.
         var args = new List<object>
         {
             "exec",
             hostDll,
-            "--no-launch-profile",
         };
 
         var resourceBuilder = builder.AddResource(resource)

--- a/src/AlmostServiceBus.Core/Amqp/AmqpIdentifiers.cs
+++ b/src/AlmostServiceBus.Core/Amqp/AmqpIdentifiers.cs
@@ -1,0 +1,64 @@
+using global::Amqp;
+using global::Amqp.Framing;
+using global::Amqp.Listener;
+
+namespace AlmostServiceBus.Core.Amqp;
+
+/// <summary>
+/// Reads and writes the AMQP message identifier fields without assuming they hold a string.
+/// AMQP 1.0 allows message-id and correlation-id to be a string, a ulong, a uuid or binary.
+/// AMQPNetLite's <see cref="Properties.MessageId"/> and <see cref="Properties.CorrelationId"/>
+/// properties cast to string, so reading either one throws InvalidCastException when the peer
+/// sent another type. The Python azure-servicebus client sends a uuid, which made every request
+/// from it fail with "Unable to cast object of type 'System.Guid' to type 'System.String'".
+/// </summary>
+internal static class AmqpIdentifiers
+{
+    /// <summary>
+    /// Sends a request's response, keeping the type of the correlation id.
+    /// </summary>
+    /// <remarks>
+    /// This replaces <see cref="RequestContext.Complete"/>, which does the same work but copies the
+    /// request's message-id through the string-typed properties. A uuid message-id therefore threw
+    /// inside AMQPNetLite before any response was sent, and the connection was closed with
+    /// amqp:internal-error. Stringifying the id instead is not an answer: a client that matches a
+    /// response to its request by message-id then never finds a match, and its request times out.
+    /// Only the state field of the context is lost, which AMQPNetLite reads for nothing else.
+    /// </remarks>
+    public static void CompleteRequest(RequestContext requestContext, Message response)
+    {
+        response.Properties ??= new Properties();
+
+        if (requestContext.Message.Properties?.GetMessageId() is { } messageId)
+            response.Properties.SetCorrelationId(messageId);
+
+        requestContext.ResponseLink.SendMessage(response);
+        requestContext.Message.Dispose();
+    }
+
+    /// <summary>
+    /// Builds the reply properties for a request, echoing the request's message-id as the
+    /// response's correlation-id and keeping the type the peer used.
+    /// </summary>
+    public static Properties CorrelateTo(Message request)
+    {
+        var properties = new Properties();
+
+        if (request.Properties?.GetMessageId() is { } messageId)
+            properties.SetCorrelationId(messageId);
+
+        return properties;
+    }
+
+    /// <summary>
+    /// The message-id as text, whatever type it arrived as, or null when there is none.
+    /// </summary>
+    public static string? MessageIdAsText(Properties properties) =>
+        properties.GetMessageId()?.ToString();
+
+    /// <summary>
+    /// The correlation-id as text, whatever type it arrived as, or null when there is none.
+    /// </summary>
+    public static string? CorrelationIdAsText(Properties properties) =>
+        properties.GetCorrelationId()?.ToString();
+}

--- a/src/AlmostServiceBus.Core/Amqp/CbsRequestProcessor.cs
+++ b/src/AlmostServiceBus.Core/Amqp/CbsRequestProcessor.cs
@@ -99,12 +99,9 @@ public class CbsRequestProcessor : IRequestProcessor
                 // renewal, flooding the CBS link with requests.
                 ["expiration"] = DateTime.UtcNow.Add(DefaultTokenExpiration)
             },
-            Properties = new Properties
-            {
-                CorrelationId = requestContext.Message.Properties?.MessageId
-            }
+            Properties = AmqpIdentifiers.CorrelateTo(requestContext.Message)
         };
-        requestContext.Complete(response);
+        AmqpIdentifiers.CompleteRequest(requestContext, response);
     }
 
     private static void TryExtractNamespace(RequestContext requestContext)

--- a/src/AlmostServiceBus.Core/Amqp/GuidDeliveryTagHandler.cs
+++ b/src/AlmostServiceBus.Core/Amqp/GuidDeliveryTagHandler.cs
@@ -14,7 +14,12 @@ namespace AlmostServiceBus.Core.Amqp;
 ///    (the Azure SDK reads the delivery tag as LockTokenGuid — if it's not
 ///    16 bytes, the SDK treats the message as "peeked" and rejects settlement).
 /// 2. Handles connection close events to clean up CBS connection tracking.
-/// 3. Prevents "OnDetach is not valid under state: Start/AttachSent" from killing
+/// 3. Emits the trailing optional fields of the local Open, Begin and Attach performatives.
+///    AMQP 1.0 allows a peer to leave them out, but the Python azure-servicebus client
+///    (pyamqp) reads Open field 9, Begin field 7 and Attach field 13 by position with no
+///    length check and raises IndexError, so it cannot connect at all unless the fields
+///    are present.
+/// 4. Prevents "OnDetach is not valid under state: Start/AttachSent" from killing
 ///    connections when clients send Detach for links whose Attach hasn't been
 ///    completed yet (e.g. session receivers waiting for a session to become available),
 ///    or during connection resets where links are locally closed in incomplete states.
@@ -57,12 +62,23 @@ public class GuidDeliveryTagHandler : IHandler
 
     public bool CanHandle(EventId id) =>
         id == EventId.SendDelivery ||
+        id == EventId.ConnectionLocalOpen ||
+        id == EventId.SessionLocalOpen ||
+        id == EventId.LinkLocalOpen ||
         id == EventId.ConnectionRemoteClose ||
         id == EventId.LinkRemoteClose ||
         id == EventId.LinkLocalClose;
 
     public void Handle(Event protocolEvent)
     {
+        if (protocolEvent.Id == EventId.ConnectionLocalOpen ||
+            protocolEvent.Id == EventId.SessionLocalOpen ||
+            protocolEvent.Id == EventId.LinkLocalOpen)
+        {
+            EmitTrailingFields(protocolEvent.Context);
+            return;
+        }
+
         if (protocolEvent.Id == EventId.ConnectionRemoteClose)
         {
             HandleConnectionRemoteClose(protocolEvent);
@@ -151,6 +167,33 @@ public class GuidDeliveryTagHandler : IHandler
         {
             Log.LogWarning(ex, "HandleLinkClose failed for link '{LinkName}' (event={EventId})",
                 link.Name, protocolEvent.Id);
+        }
+    }
+
+    /// <summary>
+    /// Makes a local Open, Begin or Attach carry its full field list.
+    /// </summary>
+    /// <remarks>
+    /// AMQP 1.0 lets a peer leave out the trailing optional fields of a performative, and
+    /// AMQPNetLite does. The Python azure-servicebus client (pyamqp) reads Open field 9, Begin
+    /// field 7 and Attach field 13 by position with no length check, and raises IndexError. Azure
+    /// itself always sends the full list, so the client never meets this in production. Setting
+    /// the last field of each performative to an empty map is enough, because only *trailing*
+    /// nulls are dropped: give the last field a value and every field before it is encoded too.
+    /// </remarks>
+    internal static void EmitTrailingFields(object? performative)
+    {
+        switch (performative)
+        {
+            case Open open:
+                open.Properties ??= new Fields();
+                break;
+            case Begin begin:
+                begin.Properties ??= new Fields();
+                break;
+            case Attach attach:
+                attach.Properties ??= new Fields();
+                break;
         }
     }
 }

--- a/src/AlmostServiceBus.Core/Amqp/ManagementLinkEndpoint.cs
+++ b/src/AlmostServiceBus.Core/Amqp/ManagementLinkEndpoint.cs
@@ -216,12 +216,9 @@ public class ManagementLinkEndpoint : IRequestProcessor
                 ["statusCode"] = 200,
                 ["statusDescription"] = "OK"
             },
-            Properties = new Properties
-            {
-                CorrelationId = requestContext.Message.Properties?.MessageId
-            }
+            Properties = AmqpIdentifiers.CorrelateTo(requestContext.Message)
         };
-        requestContext.Complete(response);
+        AmqpIdentifiers.CompleteRequest(requestContext, response);
     }
 
     private void HandleRenewLock(RequestContext requestContext)
@@ -311,12 +308,9 @@ public class ManagementLinkEndpoint : IRequestProcessor
                 ["statusCode"] = 200,
                 ["statusDescription"] = "OK"
             },
-            Properties = new Properties
-            {
-                CorrelationId = requestContext.Message.Properties?.MessageId
-            }
+            Properties = AmqpIdentifiers.CorrelateTo(requestContext.Message)
         };
-        requestContext.Complete(response);
+        AmqpIdentifiers.CompleteRequest(requestContext, response);
     }
 
     private void HandleCancelScheduledMessage(RequestContext requestContext)
@@ -378,9 +372,9 @@ public class ManagementLinkEndpoint : IRequestProcessor
                 ["statusCode"] = 200,
                 ["statusDescription"] = "OK"
             },
-            Properties = new Properties { CorrelationId = requestContext.Message.Properties?.MessageId }
+            Properties = AmqpIdentifiers.CorrelateTo(requestContext.Message)
         };
-        requestContext.Complete(response);
+        AmqpIdentifiers.CompleteRequest(requestContext, response);
     }
 
     private void HandleGetSessionState(RequestContext requestContext)
@@ -414,9 +408,9 @@ public class ManagementLinkEndpoint : IRequestProcessor
                 ["statusCode"] = 200,
                 ["statusDescription"] = "OK"
             },
-            Properties = new Properties { CorrelationId = requestContext.Message.Properties?.MessageId }
+            Properties = AmqpIdentifiers.CorrelateTo(requestContext.Message)
         };
-        requestContext.Complete(response);
+        AmqpIdentifiers.CompleteRequest(requestContext, response);
     }
 
     private void HandleSetSessionState(RequestContext requestContext)
@@ -463,9 +457,9 @@ public class ManagementLinkEndpoint : IRequestProcessor
                 ["statusCode"] = 200,
                 ["statusDescription"] = "OK"
             },
-            Properties = new Properties { CorrelationId = requestContext.Message.Properties?.MessageId }
+            Properties = AmqpIdentifiers.CorrelateTo(requestContext.Message)
         };
-        requestContext.Complete(response);
+        AmqpIdentifiers.CompleteRequest(requestContext, response);
     }
 
     /// <summary>
@@ -585,12 +579,9 @@ public class ManagementLinkEndpoint : IRequestProcessor
                 ["statusCode"] = 200,
                 ["statusDescription"] = "OK"
             },
-            Properties = new Properties
-            {
-                CorrelationId = requestContext.Message.Properties?.MessageId
-            }
+            Properties = AmqpIdentifiers.CorrelateTo(requestContext.Message)
         };
-        requestContext.Complete(response);
+        AmqpIdentifiers.CompleteRequest(requestContext, response);
     }
 
     /// <summary>
@@ -661,12 +652,9 @@ public class ManagementLinkEndpoint : IRequestProcessor
                 ["statusCode"] = 200,
                 ["statusDescription"] = "OK"
             },
-            Properties = new Properties
-            {
-                CorrelationId = requestContext.Message.Properties?.MessageId
-            }
+            Properties = AmqpIdentifiers.CorrelateTo(requestContext.Message)
         };
-        requestContext.Complete(response);
+        AmqpIdentifiers.CompleteRequest(requestContext, response);
     }
 
     /// <summary>
@@ -785,12 +773,9 @@ public class ManagementLinkEndpoint : IRequestProcessor
                 ["statusCode"] = 204,
                 ["statusDescription"] = "No Content"
             },
-            Properties = new Properties
-            {
-                CorrelationId = requestContext.Message.Properties?.MessageId
-            }
+            Properties = AmqpIdentifiers.CorrelateTo(requestContext.Message)
         };
-        requestContext.Complete(response);
+        AmqpIdentifiers.CompleteRequest(requestContext, response);
     }
 
     private void SendErrorResponse(RequestContext requestContext, int statusCode, string description, string? errorCondition = null)
@@ -802,7 +787,7 @@ public class ManagementLinkEndpoint : IRequestProcessor
                 ["statusCode"] = statusCode,
                 ["statusDescription"] = description
             },
-            Properties = new Properties { CorrelationId = requestContext.Message.Properties?.MessageId }
+            Properties = AmqpIdentifiers.CorrelateTo(requestContext.Message)
         };
 
         // The Azure SDK reads ApplicationProperties["errorCondition"] to determine the
@@ -814,7 +799,7 @@ public class ManagementLinkEndpoint : IRequestProcessor
             response.ApplicationProperties["errorCondition"] = new global::Amqp.Types.Symbol(errorCondition);
         }
 
-        requestContext.Complete(response);
+        AmqpIdentifiers.CompleteRequest(requestContext, response);
     }
 
     /// <summary>
@@ -841,11 +826,8 @@ public class ManagementLinkEndpoint : IRequestProcessor
                 ["statusCode"] = 200,
                 ["statusDescription"] = "OK"
             },
-            Properties = new Properties
-            {
-                CorrelationId = requestContext.Message.Properties?.MessageId
-            }
+            Properties = AmqpIdentifiers.CorrelateTo(requestContext.Message)
         };
-        requestContext.Complete(response);
+        AmqpIdentifiers.CompleteRequest(requestContext, response);
     }
 }

--- a/src/AlmostServiceBus.Core/Amqp/SenderLinkEndpoint.cs
+++ b/src/AlmostServiceBus.Core/Amqp/SenderLinkEndpoint.cs
@@ -213,10 +213,10 @@ public class SenderLinkEndpoint : LinkEndpoint
         {
             var props = amqpMessage.Properties;
 
-            if (props.MessageId is not null)
-                brokered.MessageId = props.MessageId.ToString()!;
-            if (props.CorrelationId is not null)
-                brokered.CorrelationId = props.CorrelationId.ToString();
+            if (AmqpIdentifiers.MessageIdAsText(props) is { } messageId)
+                brokered.MessageId = messageId;
+            if (AmqpIdentifiers.CorrelationIdAsText(props) is { } correlationId)
+                brokered.CorrelationId = correlationId;
             if (props.ContentType is not null)
                 brokered.ContentType = props.ContentType;
             if (props.Subject is not null)

--- a/src/AlmostServiceBus.Core/Amqp/ServiceBusLinkProcessor.cs
+++ b/src/AlmostServiceBus.Core/Amqp/ServiceBusLinkProcessor.cs
@@ -56,7 +56,7 @@ public class ServiceBusLinkProcessor : ILinkProcessor
 
         // The Azure SDK sends addresses with a leading '/' (e.g. "/my-queue").
         // Trim it to match entity names created via the REST API.
-        address = address?.TrimStart('/');
+        address = NormaliseAddress(address);
 
         if (string.IsNullOrEmpty(address))
         {
@@ -389,6 +389,33 @@ public class ServiceBusLinkProcessor : ILinkProcessor
 
         // 3. Default
         return _registry.GetOrCreate("default");
+    }
+
+    /// <summary>
+    /// Reduces a link address to the entity path.
+    /// </summary>
+    /// <remarks>
+    /// The .NET client sends the entity path, with or without a leading '/'. The Python client sends
+    /// the whole address it connected to, such as
+    /// "amqps://localhost:5673/my-topic/Subscriptions/my-subscription". Without this, a Python
+    /// receiver is answered "not found", and a Python sender is worse off still: the send target is
+    /// created on demand, so the URI became a queue of its own and every published message went into
+    /// it instead of the topic, with no error on either side.
+    /// </remarks>
+    internal static string? NormaliseAddress(string? address)
+    {
+        if (string.IsNullOrEmpty(address))
+            return address;
+
+        var schemeEnd = address.IndexOf("://", StringComparison.Ordinal);
+
+        if (schemeEnd >= 0)
+        {
+            var pathStart = address.IndexOf('/', schemeEnd + 3);
+            address = pathStart >= 0 ? address[pathStart..] : string.Empty;
+        }
+
+        return address.TrimStart('/');
     }
 
     private static void EnsureEntityExists(NamespaceContext context, string address)

--- a/tests/AlmostServiceBus.Tests/Amqp/PythonClientCompatibilityTests.cs
+++ b/tests/AlmostServiceBus.Tests/Amqp/PythonClientCompatibilityTests.cs
@@ -1,0 +1,136 @@
+using Amqp;
+using Amqp.Framing;
+using Amqp.Types;
+using AlmostServiceBus.Core.Amqp;
+
+namespace AlmostServiceBus.Tests.Amqp;
+
+/// <summary>
+/// The Python azure-servicebus client uses its own AMQP implementation (pyamqp), not the one the
+/// .NET client uses. These tests cover the three places where the emulator made an assumption
+/// that only holds for the .NET client.
+/// </summary>
+public class PythonClientCompatibilityTests
+{
+    [Fact]
+    public void EmitTrailingFields_GivesAnOpenItsLastField()
+    {
+        var open = new Open();
+
+        GuidDeliveryTagHandler.EmitTrailingFields(open);
+
+        Assert.NotNull(open.Properties);
+    }
+
+    [Fact]
+    public void EmitTrailingFields_GivesABeginItsLastField()
+    {
+        var begin = new Begin();
+
+        GuidDeliveryTagHandler.EmitTrailingFields(begin);
+
+        Assert.NotNull(begin.Properties);
+    }
+
+    [Fact]
+    public void EmitTrailingFields_GivesAnAttachItsLastField()
+    {
+        var attach = new Attach();
+
+        GuidDeliveryTagHandler.EmitTrailingFields(attach);
+
+        Assert.NotNull(attach.Properties);
+    }
+
+    [Fact]
+    public void EmitTrailingFields_KeepsPropertiesThatAreAlreadySet()
+    {
+        var properties = new Fields { [new Symbol("com.example")] = "value" };
+        var open = new Open { Properties = properties };
+
+        GuidDeliveryTagHandler.EmitTrailingFields(open);
+
+        Assert.Same(properties, open.Properties);
+    }
+
+    [Fact]
+    public void EmitTrailingFields_IgnoresAnythingElse()
+    {
+        GuidDeliveryTagHandler.EmitTrailingFields(null);
+        GuidDeliveryTagHandler.EmitTrailingFields(new Flow());
+    }
+
+    [Fact]
+    public void CorrelateTo_KeepsAUuidMessageId()
+    {
+        var messageId = Guid.NewGuid();
+        var request = new Message();
+        request.Properties = new Properties();
+        request.Properties.SetMessageId(messageId);
+
+        var reply = AmqpIdentifiers.CorrelateTo(request);
+
+        Assert.Equal(messageId, reply.GetCorrelationId());
+    }
+
+    [Fact]
+    public void CorrelateTo_KeepsAStringMessageId()
+    {
+        var request = new Message { Properties = new Properties { MessageId = "request-1" } };
+
+        var reply = AmqpIdentifiers.CorrelateTo(request);
+
+        Assert.Equal("request-1", reply.GetCorrelationId());
+    }
+
+    [Fact]
+    public void CorrelateTo_LeavesTheCorrelationIdUnsetWhenTheRequestHasNoMessageId()
+    {
+        Assert.Null(AmqpIdentifiers.CorrelateTo(new Message()).GetCorrelationId());
+        Assert.Null(AmqpIdentifiers.CorrelateTo(new Message { Properties = new Properties() })
+            .GetCorrelationId());
+    }
+
+    [Fact]
+    public void MessageIdAsText_ReadsAUuidWithoutThrowing()
+    {
+        var messageId = Guid.NewGuid();
+        var properties = new Properties();
+        properties.SetMessageId(messageId);
+
+        Assert.Equal(messageId.ToString(), AmqpIdentifiers.MessageIdAsText(properties));
+    }
+
+    [Fact]
+    public void CorrelationIdAsText_ReadsAUuidWithoutThrowing()
+    {
+        var correlationId = Guid.NewGuid();
+        var properties = new Properties();
+        properties.SetCorrelationId(correlationId);
+
+        Assert.Equal(correlationId.ToString(), AmqpIdentifiers.CorrelationIdAsText(properties));
+    }
+
+    [Theory]
+    // What the .NET client sends.
+    [InlineData("my-queue", "my-queue")]
+    [InlineData("/my-queue", "my-queue")]
+    [InlineData("my-topic/Subscriptions/my-subscription", "my-topic/Subscriptions/my-subscription")]
+    // What the Python client sends.
+    [InlineData("amqps://localhost:5673/my-queue", "my-queue")]
+    [InlineData(
+        "amqps://localhost:5673/my-topic/Subscriptions/my-subscription",
+        "my-topic/Subscriptions/my-subscription")]
+    [InlineData("amqp://ns.servicebus.windows.net/my-queue/$management", "my-queue/$management")]
+    // A URI with no path at all leaves no entity name.
+    [InlineData("amqps://localhost:5673", "")]
+    public void NormaliseAddress_ReducesAnAddressToTheEntityPath(string address, string expected) =>
+        Assert.Equal(expected, ServiceBusLinkProcessor.NormaliseAddress(address));
+
+    [Fact]
+    public void NormaliseAddress_PassesNullAndEmptyThrough()
+    {
+        Assert.Null(ServiceBusLinkProcessor.NormaliseAddress(null));
+        Assert.Equal(string.Empty, ServiceBusLinkProcessor.NormaliseAddress(string.Empty));
+    }
+}


### PR DESCRIPTION
Fixes #79.

Four fixes, one commit each, so you can take or drop any of them:

1. **`Emulator: emit the trailing fields of local performatives`** — set the last field of each local
   `open`, `begin` and `attach` to an empty map, so AMQPNetLite encodes the whole field list.
   `pyamqp` reads `open` field 9, `begin` field 7 and `attach` field 13 by position with no length
   check.
2. **`Emulator: keep the type of a message id in a response`** — new `AmqpIdentifiers` helper that
   reads and writes `message-id` and `correlation-id` through the object-typed AMQPNetLite methods,
   and sends a response over `RequestContext.ResponseLink` instead of `RequestContext.Complete`.
   `Complete` copies the request's message id through a string-typed property, which throws on the
   uuid that `pyamqp` sends. Stringifying the id instead breaks response matching, so the type has
   to survive.
3. **`Emulator: reduce a link address to the entity path`** — `NormaliseAddress` drops a scheme and
   authority before trimming a leading `/`. `pyamqp` sends the whole address, and because
   `EnsureEntityExists` creates a send target on demand, the URI silently became a queue of its own
   and swallowed every message a Python client published.
4. **`Aspire: stop dropping the --Port value`** — remove `--no-launch-profile` from the `dotnet exec`
   arguments. This one is unrelated to the Python work; say the word and I will move it to its own
   pull request.

Plus **`Tests: cover the Python client compatibility fixes`**, 18 unit tests over the three emulator
fixes.

## Two small API changes, for the tests

`Amqp.Handler.Event` is a struct with no accessible constructor, so a test cannot raise a protocol
event. To keep the padding testable I moved it out of `Handle` into
`GuidDeliveryTagHandler.EmitTrailingFields(object?)`, which is `internal`, and made
`ServiceBusLinkProcessor.NormaliseAddress` `internal` as well. `AlmostServiceBus.Tests` already has
`InternalsVisibleTo`. Both are easy to change if you would rather test them another way.

## Verification

Run against a stack of mixed .NET and Python clients. The Python client publishes, receives,
completes, passes a SQL filter rule, and a message it published is read by the .NET SDK with body,
application properties, subject and correlation id intact. Fifteen Python and twenty-five .NET
clients hold connections at the same time.

| Suite | Result |
| --- | --- |
| `AlmostServiceBus.Tests` | 184 passed, 0 failed |
| `AlmostServiceBus.SdkIntegration.Tests` | 45 passed, 0 failed |
| `AlmostServiceBus.MassTransit.Tests` | 29 passed, 0 failed |
| `AlmostServiceBus.Conformance.Tests`, emulator only | 35 passed, 1 failed |

`EmulatorConformanceTests.ScheduledMessage_NotReceivedBeforeScheduledTime` fails the same way on an
unpatched checkout of the same commit, so it is not from this change. The `RealAsb*` tests need
`ASB_CONNECTION_STRING` and a real namespace, so I could not run them.

## One Python limitation left

The Python management client always uses TLS and the emulator serves plain HTTP, so no Python code
can call the management API. It is out of scope here: seeding the topology with the .NET client is
enough, because the Python client only needs to publish and receive. Happy to file it separately if
you want it tracked.
