### PR TITLE
Bump NServiceBus transport submodule to upstream and track it with Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,9 @@
   "github-actions": {
     "enabled": true
   },
+  "git-submodules": {
+    "enabled": true
+  },
   "platformAutomerge": true,
   "packageRules": [
     {
@@ -23,6 +26,27 @@
         "pin"
       ],
       "automerge": true
+    },
+    {
+      "description": "Only the NServiceBus transport tracks upstream. Wolverine and MassTransit carry patches under patches/ that break when upstream moves, and azure-sdk-for-net is reference-only.",
+      "matchManagers": [
+        "git-submodules"
+      ],
+      "matchDepNames": [
+        "external/MassTransit",
+        "external/wolverine",
+        "external/azure-sdk-for-net"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Batch NServiceBus submodule bumps to one PR a week; upstream moves several times a week via its own Renovate.",
+      "matchManagers": [
+        "git-submodules"
+      ],
+      "schedule": [
+        "before 6am on monday"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Why

The **NServiceBus Tests** job has failed on every PR since 2026-07-20 (see #80). Five high-severity advisories were published that day against `System.Security.Cryptography.Xml` 10.0.6, a transitive dependency of the NServiceBus 10.1.3 that the old submodule commit pins. The submodule builds with `NuGetAuditLevel=low` and warnings-as-errors, so restore fails with NU1903 before any test runs. Main's last green run was 2026-07-16.

## What

- **Bump `external/NServiceBus.Transport.AzureServiceBus`** from `ae9190c` (2026-04-15) to upstream master `ae69812` (2026-09-09, NServiceBus 10.2.9). All 287 transport tests pass locally with the exact CI command.
- **Enable Renovate's `git-submodules` manager** in `renovate.json` so the pin follows upstream automatically:
  - Only the NServiceBus submodule is tracked. Wolverine and MassTransit are disabled because they carry patches under `patches/` that break when upstream moves, and `azure-sdk-for-net` is reference-only.
  - Bumps are scheduled to one PR a week (Monday before 06:00 UTC), since Particular's own Renovate moves upstream several times a week.
  - Submodule bumps are `digest` updates, so they fall under the existing automerge rule and land on their own when CI is green.

Once this is in, #80 needs a rebase or a rerun to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
