### PR TITLE
Renovate: group related updates and pin MassTransit <9 and TypeScript <7

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,54 @@
       "automerge": true
     },
     {
+      "description": "OrderFlowDemo sample: one grouped PR a month, never auto-merged. CI does not build the sample, so a green check proves nothing about it, and it is not part of any released package.",
+      "matchFileNames": [
+        "samples/**"
+      ],
+      "groupName": "OrderFlowDemo sample dependencies",
+      "schedule": [
+        "before 6am on the first day of the month"
+      ],
+      "automerge": false
+    },
+    {
+      "description": "Dashboard frontend toolchain (vite, vue-tsc, plugin-vue, typescript, vue): one grouped PR so the lockfile is regenerated once and the Host build runs once.",
+      "matchFileNames": [
+        "src/AlmostServiceBus.Dashboard/**"
+      ],
+      "groupName": "dashboard frontend dependencies"
+    },
+    {
+      "description": "GitHub Actions: one grouped PR.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github actions"
+    },
+    {
+      "description": ".NET test tooling: one grouped PR across every test project.",
+      "matchPackageNames": [
+        "Microsoft.NET.Test.Sdk",
+        "coverlet.collector",
+        "/^xunit/"
+      ],
+      "groupName": ".NET test tooling"
+    },
+    {
+      "description": "MassTransit 9 moved from Apache-2.0 to a proprietary licence (massient.com/license). Stay on the open-source 8.x line.",
+      "allowedVersions": "<9",
+      "matchPackageNames": [
+        "/^MassTransit/"
+      ]
+    },
+    {
+      "description": "vue-tsc cannot resolve the TypeScript 7 compiler entry point yet, so TS 7 breaks the dashboard build. Hold at 5.x until vue-tsc supports it.",
+      "matchPackageNames": [
+        "typescript"
+      ],
+      "allowedVersions": "<7"
+    },
+    {
       "description": "Only the NServiceBus transport tracks upstream. Wolverine and MassTransit carry patches under patches/ that break when upstream moves, and azure-sdk-for-net is reference-only.",
       "matchManagers": [
         "git-submodules"


### PR DESCRIPTION
Thirteen single-dependency PRs were open, each running the full CI matrix. This groups related bumps so they land as one PR and one CI run, and adds two pins.

## Grouping

| Scope | Rule |
|---|---|
| `samples/**` | One grouped PR a month, **never auto-merged**. CI does not build the OrderFlowDemo sample, so a green check proves nothing about it, and it is not part of any released package. |
| `src/AlmostServiceBus.Dashboard/**` | One grouped PR, so the lockfile is regenerated once and the Host build runs once. |
| GitHub Actions | One grouped PR. |
| .NET test tooling (`xunit*`, `Microsoft.NET.Test.Sdk`, `coverlet.collector`) | One grouped PR across every test project. |

## Pins

- **MassTransit `<9`**. 9.x moved from Apache-2.0 to a proprietary licence (`massient.com/license`, see the 9.2.1 nuspec). Stay on the open-source 8.x line. Closes the door on #85.
- **typescript `<7`**. vue-tsc 3 cannot resolve the TypeScript 7 compiler entry point (`resolveTscPath` throws), so TS 7 breaks the dashboard build. Closes the door on #65 until vue-tsc catches up.

Existing rules (non-major automerge, NServiceBus submodule tracking) are unchanged. Validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
