### PR TITLE
Fix OrderFlowDemo run.ps1 and README connection strings (missing UseDevelopmentEmulator=true)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ almost-servicebus
 
 Connection string:
 ```
-Endpoint=sb://localhost:5672;SharedAccessKeyName=<my-namespace>;SharedAccessKey=emulator
+Endpoint=sb://localhost:5672;SharedAccessKeyName=<my-namespace>;SharedAccessKey=emulator;UseDevelopmentEmulator=true
 ```
 *Note: using "RootManageSharedAccessKey" as the SharedAccessKeyName will map to the 'default' namespace.*
 

--- a/samples/OrderFlowDemo/run.ps1
+++ b/samples/OrderFlowDemo/run.ps1
@@ -16,7 +16,7 @@ $ErrorActionPreference = "Stop"
 $scriptDir = $PSScriptRoot
 $repoRoot  = Resolve-Path "$scriptDir\..\.."
 
-$connStr = "Endpoint=sb://localhost:5672;SharedAccessKeyName=OrderFlowDemo;SharedAccessKey=emulator"
+$connStr = "Endpoint=sb://localhost:5672;SharedAccessKeyName=OrderFlowDemo;SharedAccessKey=emulator;UseDevelopmentEmulator=true"
 
 # Build the Vue dashboard so changes are picked up
 Write-Host "Building Vue dashboard..." -ForegroundColor Cyan


### PR DESCRIPTION
## Symptom

Running the OrderFlowDemo via `run.ps1`, both OrderApi and FulfillmentWorker fault every receive endpoint:

```
MassTransit.ServiceBusConnectionException: ReceiveTransport faulted: sb://localhost:5672/ProcessPayment
 ---> Azure.RequestFailedException: The SSL connection could not be established
 ---> System.Net.Sockets.SocketException (10054): An existing connection was forcibly closed by the remote host.
```

## Cause

The emulator has been plaintext-only since #31. The Azure SDK only uses plain AMQP and plain admin HTTP when the connection string carries `UseDevelopmentEmulator=true`. `run.ps1` was last touched before that change and still hands the apps a string without the flag, so MassTransit's administration client speaks TLS to a plaintext port.

The Aspire AppHost path was never affected, because `AlmostServiceBusResource` already emits the flag in its connection string expression. The README quick-start connection string had the same gap.

## Fix

Append `;UseDevelopmentEmulator=true` in `run.ps1` and the README.

## Verification

- `run.ps1` process layout (emulator + OrderApi + FulfillmentWorker as separate processes) with the fixed string: steady-state scenario ran 44 orders, 36 completed, 4 expected payment failures, zero errors in any log.
- Aspire AppHost path: 34 orders, 27 completed, zero errors, confirming it still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
