### PR TITLE
Keep the OrderFlow dashboard responsive under Black Friday load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ All notable changes to this project are documented here. The format is based on
 - OrderFlow demo: the fulfillment worker now has a retry policy, so the
   `ShipOrderConsumer`'s "will retry" is true and Black Friday runs drain
   completely instead of parking ~2% of orders in `logistics-dispatch_error`.
+- OrderFlow demo dashboard: the browser tab no longer freezes under Black
+  Friday load. Counters and pipeline state are polled from the API once a
+  second (and resynced when the SSE stream reconnects) instead of being
+  counted from events, so dropped bursts no longer skew the numbers; the
+  throughput chart uses a fixed 60-bucket ring instead of re-filtering every
+  event; SSE events are applied on a 250 ms tick with chart animation off; the
+  server batches SSE writes, sends keep-alives and buffers 4096 events per
+  subscriber.
 
 ## [0.4.0] - 2026-09-10
 

--- a/samples/OrderFlowDemo/OrderFlowDemo.OrderApi/ClientApp/src/App.vue
+++ b/samples/OrderFlowDemo/OrderFlowDemo.OrderApi/ClientApp/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useSse } from './composables/useSse'
 import { useDashboardStore } from './composables/useDashboardStore'
+import { useSnapshotPolling } from './composables/useSnapshotPolling'
 import ScenarioBar from './components/ScenarioBar.vue'
 import MetricCards from './components/MetricCards.vue'
 import PipelineFlow from './components/PipelineFlow.vue'
@@ -10,10 +11,17 @@ import QueueDepths from './components/QueueDepths.vue'
 import WarehouseFifo from './components/WarehouseFifo.vue'
 import LiveFeed from './components/LiveFeed.vue'
 
-const { connected, onEvent } = useSse('/api/dashboard/events')
-const { state, processEvent, inFlight, throughputPerSecond } = useDashboardStore()
+const store = useDashboardStore()
+const { state, processEvent, inFlight, throughputPerSecond } = store
 
+// Counters and pipeline state are polled from the API (authoritative); the SSE stream only
+// drives the live feed and the throughput chart, so a dropped burst can't skew the numbers.
+const polling = useSnapshotPolling(store)
+polling.start()
+
+const { connected, onEvent, onOpen } = useSse('/api/dashboard/events')
 onEvent(processEvent)
+onOpen(() => { void polling.refresh() })
 </script>
 
 <template>
@@ -54,7 +62,7 @@ onEvent(processEvent)
         <!-- Throughput chart full width -->
         <div class="card">
           <div class="card-title">Throughput — 60 s window <span class="card-badge">STREAMING</span></div>
-          <ThroughputChart :history="state.throughputHistory" />
+          <ThroughputChart :buckets="state.throughputBuckets" />
         </div>
 
         <!-- Bottom 3-col grid -->

--- a/samples/OrderFlowDemo/OrderFlowDemo.OrderApi/ClientApp/src/components/SagaDonut.vue
+++ b/samples/OrderFlowDemo/OrderFlowDemo.OrderApi/ClientApp/src/components/SagaDonut.vue
@@ -44,6 +44,8 @@ const options = {
     legend: { position: 'right' as const, labels: { font: { size: 11 } } },
   },
   cutout: '65%',
+  // Counts refresh once a second from the API; animating every change is wasted work under load.
+  animation: false as const,
 }
 </script>
 

--- a/samples/OrderFlowDemo/OrderFlowDemo.OrderApi/ClientApp/src/components/ThroughputChart.vue
+++ b/samples/OrderFlowDemo/OrderFlowDemo.OrderApi/ClientApp/src/components/ThroughputChart.vue
@@ -14,36 +14,30 @@ import {
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Filler, Tooltip)
 
 const props = defineProps<{
-  history: { time: number; count: number }[]
+  /** Events per second for the last 60 seconds, oldest first (see useDashboardStore). */
+  buckets: number[]
 }>()
 
-const chartData = computed(() => {
-  const now = Date.now()
-  const buckets: number[] = new Array(60).fill(0)
-  for (const entry of props.history) {
-    const secondsAgo = Math.floor((now - entry.time) / 1000)
-    if (secondsAgo < 60) {
-      buckets[59 - secondsAgo]++
-    }
-  }
-  const labels = buckets.map((_, i) => i === 59 ? 'now' : `${59 - i}s`)
-  return {
-    labels,
-    datasets: [{
-      label: 'Events/sec',
-      data: buckets,
-      fill: true,
-      borderColor: '#068d9d',
-      backgroundColor: 'rgba(6,141,157,0.2)',
-      tension: 0.3,
-      pointRadius: 0,
-    }],
-  }
-})
+const labels = Array.from({ length: 60 }, (_, i) => i === 59 ? 'now' : `${59 - i}s`)
+
+const chartData = computed(() => ({
+  labels,
+  datasets: [{
+    label: 'Events/sec',
+    data: props.buckets,
+    fill: true,
+    borderColor: '#068d9d',
+    backgroundColor: 'rgba(6,141,157,0.2)',
+    tension: 0.3,
+    pointRadius: 0,
+  }],
+}))
 
 const options = {
   responsive: true,
   maintainAspectRatio: false,
+  // The data is refreshed on a fixed tick; animating between ticks just burns main-thread time.
+  animation: false as const,
   plugins: { legend: { display: false } },
   scales: {
     x: { display: false },

--- a/samples/OrderFlowDemo/OrderFlowDemo.OrderApi/ClientApp/src/composables/useDashboardStore.ts
+++ b/samples/OrderFlowDemo/OrderFlowDemo.OrderApi/ClientApp/src/composables/useDashboardStore.ts
@@ -11,91 +11,157 @@ export interface FeedItem {
   timestamp: string
 }
 
+/** Shape of GET /api/dashboard/stats */
+export interface StatsSnapshot {
+  total: number
+  completed: number
+  failed: number
+  inFlight: number
+}
+
+/** Shape of GET /api/dashboard/pipeline (only states with count > 0 are returned) */
+export type PipelineSnapshot = { state: string; count: number }[]
+
+/** Shape of GET /api/dashboard/warehouses */
+export type WarehouseSnapshot = { warehouseId: string; depth: number }[]
+
+const MAX_FEED_ITEMS = 50
+const THROUGHPUT_WINDOW_SECONDS = 60
+/** How often buffered SSE events are applied to reactive state. */
+const RENDER_INTERVAL_MS = 250
+
 const state = reactive({
+  // Authoritative numbers come from polling the API, not from counting events. Counting
+  // events client-side drifted permanently whenever a burst dropped or the stream reconnected.
   pipelineCounts: {} as Record<string, number>,
   warehouseDepths: {} as Record<string, number>,
   totalOrders: 0,
   completedOrders: 0,
   failedOrders: 0,
+  inFlightOrders: 0,
+  // Live feed and throughput are the only things derived from the SSE stream.
   feedItems: [] as FeedItem[],
-  throughputHistory: [] as { time: number; count: number }[],
-  recentEventCount: 0,
+  /** Events per second for the last 60 seconds, oldest first. */
+  throughputBuckets: new Array<number>(THROUGHPUT_WINDOW_SECONDS).fill(0),
 })
-
-const TERMINAL_STATES = ['Invoiced', 'Final']
-const FAILURE_STATES = ['PaymentFailed', 'BackOrdered']
-const MAX_FEED_ITEMS = 50
-const THROUGHPUT_WINDOW_MS = 60_000
 
 let eventCounter = 0
 
-export function useDashboardStore() {
-  function processEvent(event: DashboardEvent) {
-    if (event.type !== 'saga-transition') return
+// Ring buffer of per-second counts keyed by epoch second. O(1) per event, regardless of rate.
+// The previous implementation kept one entry per event and rebuilt the whole array on every
+// event, which at Black Friday rates (~450 events/s) meant copying tens of thousands of entries
+// hundreds of times a second and froze the tab.
+const ring = new Array<number>(THROUGHPUT_WINDOW_SECONDS).fill(0)
+const ringSeconds = new Array<number>(THROUGHPUT_WINDOW_SECONDS).fill(-1)
 
-    const toState = event.toState
-    if (!toState) return
+function bumpThroughput(nowMs: number) {
+  const second = Math.floor(nowMs / 1000)
+  const slot = second % THROUGHPUT_WINDOW_SECONDS
+  if (ringSeconds[slot] !== second) {
+    ringSeconds[slot] = second
+    ring[slot] = 0
+  }
+  ring[slot]++
+}
 
-    // Update pipeline counts
-    if (event.fromState && state.pipelineCounts[event.fromState] > 0) {
-      state.pipelineCounts[event.fromState]--
-    }
-    state.pipelineCounts[toState] = (state.pipelineCounts[toState] || 0) + 1
+function snapshotThroughput(nowMs: number): number[] {
+  const nowSecond = Math.floor(nowMs / 1000)
+  const out = new Array<number>(THROUGHPUT_WINDOW_SECONDS)
+  for (let i = 0; i < THROUGHPUT_WINDOW_SECONDS; i++) {
+    const second = nowSecond - (THROUGHPUT_WINDOW_SECONDS - 1 - i)
+    const slot = second % THROUGHPUT_WINDOW_SECONDS
+    out[i] = ringSeconds[slot] === second ? ring[slot] : 0
+  }
+  return out
+}
 
-    // Track totals
-    if (!event.fromState) {
-      state.totalOrders++
-    }
-    if (TERMINAL_STATES.includes(toState)) {
-      state.completedOrders++
-    }
-    if (FAILURE_STATES.includes(toState)) {
-      state.failedOrders++
-    }
+// Incoming events are buffered and applied on a timer so rendering cost is bounded by the
+// timer, not by the event rate. Every component (including two Chart.js charts) re-renders
+// on each reactive flush, so one flush per event was the other half of the freeze.
+let pending: DashboardEvent[] = []
+let flushTimer: ReturnType<typeof setInterval> | null = null
 
-    // Warehouse depths — order enters warehouse at Picking, leaves at Shipping
-    if (event.warehouse) {
-      if (toState === 'Picking') {
-        state.warehouseDepths[event.warehouse] = (state.warehouseDepths[event.warehouse] || 0) + 1
-      } else if (toState === 'Shipping' || FAILURE_STATES.includes(toState)) {
-        state.warehouseDepths[event.warehouse] = Math.max(
-          0, (state.warehouseDepths[event.warehouse] || 0) - 1)
-      }
-    }
+function flushPending() {
+  const now = Date.now()
+  if (pending.length > 0) {
+    const batch = pending
+    pending = []
 
-    // Feed
-    state.feedItems.unshift({
-      id: `${++eventCounter}`,
-      type: event.type,
-      orderId: event.orderId,
-      state: toState,
-      warehouse: event.warehouse ?? undefined,
-      failureReason: event.failureReason ?? undefined,
-      timestamp: event.timestamp,
-    })
-    if (state.feedItems.length > MAX_FEED_ITEMS) {
-      state.feedItems.length = MAX_FEED_ITEMS
+    const newItems: FeedItem[] = []
+    for (const event of batch) {
+      if (event.type !== 'saga-transition' || !event.toState) continue
+      bumpThroughput(new Date(event.timestamp).getTime() || now)
+      newItems.push({
+        id: `${++eventCounter}`,
+        type: event.type,
+        orderId: event.orderId,
+        state: event.toState,
+        warehouse: event.warehouse ?? undefined,
+        failureReason: event.failureReason ?? undefined,
+        timestamp: event.timestamp,
+      })
     }
 
-    // Throughput tracking
-    const now = Date.now()
-    state.throughputHistory.push({ time: now, count: 1 })
-    state.throughputHistory = state.throughputHistory.filter(
-      e => now - e.time < THROUGHPUT_WINDOW_MS)
-    state.recentEventCount = state.throughputHistory.length
+    if (newItems.length > 0) {
+      // Newest first; only the last MAX_FEED_ITEMS of the batch can be visible anyway.
+      newItems.reverse()
+      state.feedItems = newItems.slice(0, MAX_FEED_ITEMS)
+        .concat(state.feedItems)
+        .slice(0, MAX_FEED_ITEMS)
+    }
   }
 
-  const inFlight = computed(() =>
-    state.totalOrders - state.completedOrders - state.failedOrders)
+  // Refresh the chart even when idle so the window keeps sliding to the right.
+  state.throughputBuckets = snapshotThroughput(now)
+}
 
-  const throughputPerSecond = computed(() =>
-    state.throughputHistory.length > 0
-      ? Math.round(state.recentEventCount / (THROUGHPUT_WINDOW_MS / 1000) * 10) / 10
-      : 0)
+function ensureFlushTimer() {
+  if (flushTimer === null) {
+    flushTimer = setInterval(flushPending, RENDER_INTERVAL_MS)
+  }
+}
+
+export function useDashboardStore() {
+  ensureFlushTimer()
+
+  /** Queue an SSE event; it is applied to state on the next render tick. */
+  function processEvent(event: DashboardEvent) {
+    pending.push(event)
+  }
+
+  function applyStats(stats: StatsSnapshot) {
+    state.totalOrders = stats.total
+    state.completedOrders = stats.completed
+    state.failedOrders = stats.failed
+    state.inFlightOrders = stats.inFlight
+  }
+
+  function applyPipeline(pipeline: PipelineSnapshot) {
+    // The API omits zero-count states, so replace the map rather than merging into it.
+    const counts: Record<string, number> = {}
+    for (const entry of pipeline) counts[entry.state] = entry.count
+    state.pipelineCounts = counts
+  }
+
+  function applyWarehouses(warehouses: WarehouseSnapshot) {
+    const depths: Record<string, number> = {}
+    for (const entry of warehouses) depths[entry.warehouseId] = entry.depth
+    state.warehouseDepths = depths
+  }
+
+  const inFlight = computed(() => state.inFlightOrders)
+
+  const throughputPerSecond = computed(() => {
+    const total = state.throughputBuckets.reduce((sum, n) => sum + n, 0)
+    return Math.round(total / THROUGHPUT_WINDOW_SECONDS * 10) / 10
+  })
 
   return {
     state,
     processEvent,
+    applyStats,
+    applyPipeline,
+    applyWarehouses,
     inFlight,
     throughputPerSecond,
   }

--- a/samples/OrderFlowDemo/OrderFlowDemo.OrderApi/ClientApp/src/composables/useSnapshotPolling.ts
+++ b/samples/OrderFlowDemo/OrderFlowDemo.OrderApi/ClientApp/src/composables/useSnapshotPolling.ts
@@ -1,0 +1,55 @@
+import { onUnmounted } from 'vue'
+import type { PipelineSnapshot, StatsSnapshot, WarehouseSnapshot } from './useDashboardStore'
+
+export interface SnapshotSink {
+  applyStats(stats: StatsSnapshot): void
+  applyPipeline(pipeline: PipelineSnapshot): void
+  applyWarehouses(warehouses: WarehouseSnapshot): void
+}
+
+/**
+ * Polls the dashboard API for the authoritative counters. The server keeps these in
+ * DashboardStats and they are correct regardless of how many SSE events reached the browser,
+ * so a dropped burst or a stream reconnect costs a few lines in the live feed instead of
+ * leaving every number on the page permanently wrong.
+ */
+export function useSnapshotPolling(sink: SnapshotSink, intervalMs = 1000) {
+  let timer: ReturnType<typeof setInterval> | null = null
+  let inFlight = false
+
+  async function refresh() {
+    if (inFlight) return
+    inFlight = true
+    try {
+      const [stats, pipeline, warehouses] = await Promise.all([
+        fetch('/api/dashboard/stats').then(r => r.json() as Promise<StatsSnapshot>),
+        fetch('/api/dashboard/pipeline').then(r => r.json() as Promise<PipelineSnapshot>),
+        fetch('/api/dashboard/warehouses').then(r => r.json() as Promise<WarehouseSnapshot>),
+      ])
+      sink.applyStats(stats)
+      sink.applyPipeline(pipeline)
+      sink.applyWarehouses(warehouses)
+    } catch {
+      // Backend unreachable (e.g. Vite dev without the API) — keep the last snapshot.
+    } finally {
+      inFlight = false
+    }
+  }
+
+  function start() {
+    if (timer !== null) return
+    void refresh()
+    timer = setInterval(() => { void refresh() }, intervalMs)
+  }
+
+  function stop() {
+    if (timer !== null) {
+      clearInterval(timer)
+      timer = null
+    }
+  }
+
+  onUnmounted(stop)
+
+  return { refresh, start, stop }
+}

--- a/samples/OrderFlowDemo/OrderFlowDemo.OrderApi/ClientApp/src/composables/useSse.ts
+++ b/samples/OrderFlowDemo/OrderFlowDemo.OrderApi/ClientApp/src/composables/useSse.ts
@@ -18,10 +18,16 @@ export function useSse(url: string) {
   const connected = ref(false)
   const lastEvent = ref<DashboardEvent | null>(null)
   const handlers: Array<(event: DashboardEvent) => void> = []
+  const openHandlers: Array<() => void> = []
 
   const eventSource = new EventSource(url)
 
-  eventSource.onopen = () => { connected.value = true }
+  eventSource.onopen = () => {
+    connected.value = true
+    // Fires on the initial connect and after every automatic reconnect. Anything sent while
+    // we were disconnected is gone (SSE has no replay here), so listeners resync from the API.
+    openHandlers.forEach(h => h())
+  }
   eventSource.onerror = () => { connected.value = false }
 
   eventSource.onmessage = (e) => {
@@ -34,9 +40,13 @@ export function useSse(url: string) {
     handlers.push(handler)
   }
 
+  function onOpen(handler: () => void) {
+    openHandlers.push(handler)
+  }
+
   onUnmounted(() => {
     eventSource.close()
   })
 
-  return { connected, lastEvent, onEvent }
+  return { connected, lastEvent, onEvent, onOpen }
 }

--- a/samples/OrderFlowDemo/OrderFlowDemo.OrderApi/Dashboard/DashboardEventBus.cs
+++ b/samples/OrderFlowDemo/OrderFlowDemo.OrderApi/Dashboard/DashboardEventBus.cs
@@ -35,7 +35,11 @@ public class DashboardEventBus
 
     public ChannelReader<DashboardEvent> Subscribe()
     {
-        var channel = Channel.CreateBounded<DashboardEvent>(new BoundedChannelOptions(256)
+        // Sized for a few seconds of Black Friday output (~450 events/s) so a briefly slow
+        // subscriber doesn't lose events. Beyond that we still drop rather than block the
+        // saga's consume pipeline; the dashboard's counters are polled, not event-sourced, so a
+        // drop only costs feed lines.
+        var channel = Channel.CreateBounded<DashboardEvent>(new BoundedChannelOptions(4096)
         {
             FullMode = BoundedChannelFullMode.DropOldest,
         });

--- a/samples/OrderFlowDemo/OrderFlowDemo.OrderApi/Dashboard/DashboardSseEndpoint.cs
+++ b/samples/OrderFlowDemo/OrderFlowDemo.OrderApi/Dashboard/DashboardSseEndpoint.cs
@@ -1,4 +1,6 @@
+using System.Text;
 using System.Text.Json;
+using System.Threading.Channels;
 
 namespace OrderFlowDemo.OrderApi.Dashboard;
 
@@ -8,6 +10,12 @@ public static class DashboardSseEndpoint
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
     };
+
+    /// <summary>
+    /// How long the stream may stay silent before a comment line is sent to keep the
+    /// connection (and any proxy in between) alive.
+    /// </summary>
+    private static readonly TimeSpan KeepAliveInterval = TimeSpan.FromSeconds(15);
 
     public static IEndpointRouteBuilder MapDashboardSse(this IEndpointRouteBuilder app)
     {
@@ -20,15 +28,49 @@ public static class DashboardSseEndpoint
             httpContext.Response.Headers.CacheControl = "no-cache";
             httpContext.Response.Headers.Connection = "keep-alive";
 
+            // Flush the headers immediately so EventSource fires onopen without waiting for
+            // the first event.
+            await httpContext.Response.WriteAsync(": connected\n\n", ct);
+            await httpContext.Response.Body.FlushAsync(ct);
+
             var reader = eventBus.Subscribe();
+            var buffer = new StringBuilder();
             try
             {
-                await foreach (var evt in reader.ReadAllAsync(ct))
+                while (!ct.IsCancellationRequested)
                 {
-                    var json = JsonSerializer.Serialize(evt, JsonOpts);
-                    await httpContext.Response.WriteAsync($"data: {json}\n\n", ct);
-                    await httpContext.Response.Body.FlushAsync(ct);
+                    // Wait for the next event, but not forever: a silent stream gets a
+                    // keep-alive comment instead.
+                    var hasData = await WaitToReadAsync(reader, KeepAliveInterval, ct);
+                    if (!hasData)
+                    {
+                        await httpContext.Response.WriteAsync(": keep-alive\n\n", ct);
+                        await httpContext.Response.Body.FlushAsync(ct);
+                        continue;
+                    }
+
+                    // Drain whatever has accumulated and send it as one write + flush. Under
+                    // load (hundreds of transitions a second) one flush per event was a
+                    // syscall per event; batching keeps the writer ahead of the publisher so
+                    // the bounded channel doesn't have to drop anything.
+                    buffer.Clear();
+                    while (reader.TryRead(out var evt))
+                    {
+                        buffer.Append("data: ");
+                        buffer.Append(JsonSerializer.Serialize(evt, JsonOpts));
+                        buffer.Append("\n\n");
+                    }
+
+                    if (buffer.Length > 0)
+                    {
+                        await httpContext.Response.WriteAsync(buffer.ToString(), ct);
+                        await httpContext.Response.Body.FlushAsync(ct);
+                    }
                 }
+            }
+            catch (OperationCanceledException)
+            {
+                // Client went away.
             }
             finally
             {
@@ -37,5 +79,23 @@ public static class DashboardSseEndpoint
         });
 
         return app;
+    }
+
+    /// <summary>
+    /// Returns true when the reader has data, false when <paramref name="timeout"/> elapsed
+    /// first. Cancellation of <paramref name="ct"/> propagates as an exception.
+    /// </summary>
+    private static async Task<bool> WaitToReadAsync(ChannelReader<DashboardEvent> reader, TimeSpan timeout, CancellationToken ct)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(timeout);
+        try
+        {
+            return await reader.WaitToReadAsync(timeoutCts.Token);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Stacked on #95 (shares its CHANGELOG "Unreleased" section). Retarget to `main` once #95 merges.

## Problem

During the black-friday scenario the dashboard tab appears to stop receiving updates, flips to DISCONNECTED, and afterwards shows numbers that never line up with reality.

The server was not overloaded: `/api/dashboard/stats` answered instantly throughout both load runs. The browser tab was the bottleneck. Every SSE event (~450/s at peak):

- rebuilt the whole 60 s throughput history array with `filter` (tens of thousands of entries, hundreds of times a second),
- triggered a full Vue flush including two Chart.js redraws,
- unshifted into the feed list.

The main thread saturated and the tab stopped painting. Once frozen, the browser stopped draining the socket, Kestrel's minimum response data rate aborted the connection, `EventSource` reconnected with no replay, and the server-side 256-slot `DropOldest` channel had been discarding too. Because every counter on the page was event-sourced (`pipelineCounts++/--`, totals, warehouse depths), any gap left the display permanently wrong.

## Changes

**Client (`ClientApp/src`)**
- `useSnapshotPolling` polls `/api/dashboard/stats`, `/pipeline` and `/warehouses` once a second and on every SSE `onopen` (initial connect and reconnect). These are the authoritative numbers now; SSE only drives the live feed and the throughput chart.
- `useDashboardStore`: throughput is a fixed 60-bucket per-second ring (O(1) per event); incoming events are buffered and applied on a 250 ms tick; pipeline snapshots replace the map (the API omits zero-count states).
- `ThroughputChart` takes the bucket array; both Chart.js charts have animation off.

**Server (`Dashboard/`)**
- `DashboardSseEndpoint`: flushes headers immediately, drains the channel and writes each batch with a single flush, sends a `: keep-alive` comment after 15 s idle.
- `DashboardEventBus`: per-subscriber buffer 256 → 4096.

## Verification

- `npm run build` (vue-tsc) and `dotnet build` clean.
- Compiled store under node: 20,000 events ingested in ~20 ms with no reactive writes; feed capped at 50 newest-first; ring buckets sum to 20,000 across the right seconds; pipeline replace semantics correct.
- Live black-friday run: SSE endpoint streamed ~160 events/s at peak with keep-alives, stats API answered instantly, zero API errors.
- Not verified in a real browser tab (Chrome extension wasn't connected in this session). Worth a manual look at the dashboard during black-friday before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
