### PR TITLE
Nodejs concurrent connections amqnetlite fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,16 @@ jobs:
         with:
           dotnet-version: "10.x"
 
+      # The Node SDK opens several connections concurrently; the emulator relies on the
+      # AMQPNetLite listener deferring its Open frame (patches/amqpnetlite,
+      # https://github.com/Azure/amqpnetlite/pull/651). Build the host against the patched
+      # source so the smoke tests exercise that fix.
+      - name: Checkout AMQPNetLite submodule
+        run: git submodule update --init --depth 1 external/amqpnetlite
+
+      - name: Apply submodule patches
+        run: pwsh apply-patches.ps1
+
       - name: Build emulator host
         run: dotnet build src/AlmostServiceBus.Host
 
@@ -169,6 +179,14 @@ jobs:
         run: |
           npm ci --no-audit --no-fund
           node smoke.mjs
+
+      # Concurrent-connection regression guard for amqpnetlite PR #651: hangs against an
+      # unpatched listener, passes against the patched source the smoke job builds.
+      - name: Run Node.js concurrent-connection test
+        if: matrix.sdk == 'node'
+        timeout-minutes: 5
+        working-directory: tests/client-sdk-smoke/node
+        run: node concurrent-connections.mjs
 
       # ── Java ──
       - name: Setup Java

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,7 @@
 [submodule "external/azure-sdk-for-net"]
 	path = external/azure-sdk-for-net
 	url = https://github.com/Azure/azure-sdk-for-net.git
+[submodule "external/amqpnetlite"]
+	path = external/amqpnetlite
+	url = https://github.com/Azure/amqpnetlite.git
+	ignore = dirty

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,17 @@
     <MinVerMinimumMajorMinor>0.1</MinVerMinimumMajorMinor>
   </PropertyGroup>
 
+  <!-- Build against the vendored, patched AMQPNetLite source when the submodule is checked
+       out (see patches/amqpnetlite and https://github.com/Azure/amqpnetlite/pull/651).
+       Otherwise projects fall back to the published AMQPNetLite NuGet package. Set
+       UseAmqpNetLiteSource=false to force the package even when the submodule is present. -->
+  <PropertyGroup>
+    <AmqpNetLiteSourceProject>$(MSBuildThisFileDirectory)external/amqpnetlite/src/Amqp.csproj</AmqpNetLiteSourceProject>
+    <AmqpNetLitePackageVersion>2.5.4</AmqpNetLitePackageVersion>
+    <UseAmqpNetLiteSource Condition="'$(UseAmqpNetLiteSource)' == '' and Exists('$(AmqpNetLiteSourceProject)')">true</UseAmqpNetLiteSource>
+    <UseAmqpNetLiteSource Condition="'$(UseAmqpNetLiteSource)' == ''">false</UseAmqpNetLiteSource>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="MinVer" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/patches/amqpnetlite/0001-defer-listener-open-frame.patch
+++ b/patches/amqpnetlite/0001-defer-listener-open-frame.patch
@@ -1,0 +1,91 @@
+diff --git a/src/Connection.cs b/src/Connection.cs
+index 7f19b77..6324926 100644
+--- a/src/Connection.cs
++++ b/src/Connection.cs
+@@ -121,6 +121,16 @@ namespace Amqp
+         uint remoteMaxFrameSize;
+         ITransport writer;
+         HeartBeat heartBeat;
++        Open deferredOpen;
++
++        // When false, the local Open is not pipelined with the protocol header but is
++        // deferred until the peer's protocol header is received. Listener connections
++        // set this to avoid coalescing the header and Open into a single TCP segment,
++        // which some clients (e.g. the Node rhea library) fail to parse.
++        internal virtual bool PipelineOpen
++        {
++            get { return true; }
++        }
+ 
+         Connection(Address address, ushort channelMax, uint maxFrameSize)
+         {
+@@ -280,8 +290,17 @@ namespace Amqp
+             }
+ 
+             this.SendHeader();
+-            this.SendOpen(open);
+-            this.state = ConnectionState.OpenPipe;
++            if (this.PipelineOpen)
++            {
++                this.SendOpen(open);
++                this.state = ConnectionState.OpenPipe;
++            }
++            else
++            {
++                // Defer the Open until the peer's protocol header arrives (see PipelineOpen).
++                this.deferredOpen = open;
++                this.state = ConnectionState.HeaderSent;
++            }
+         }
+ 
+         static ConnectionFactory connectionFactory;
+@@ -517,6 +536,14 @@ namespace Amqp
+                 {
+                     newState = ConnectionState.OpenClosePipe;
+                 }
++                else if (this.state == ConnectionState.HeaderSent)
++                {
++                    // Non-pipelined Open was deferred and never sent; send it now so the
++                    // peer sees a well-formed Open/Close sequence once its header arrives.
++                    this.SendOpen(this.deferredOpen);
++                    this.deferredOpen = null;
++                    newState = ConnectionState.OpenClosePipe;
++                }
+                 else if (state == ConnectionState.OpenSent)
+                 {
+                     newState = ConnectionState.ClosePipe;
+@@ -764,6 +791,15 @@ namespace Amqp
+                 {
+                     this.state = ConnectionState.OpenSent;
+                 }
++                else if (this.state == ConnectionState.HeaderSent)
++                {
++                    // Deferred (non-pipelined) Open: now that the peer's header has
++                    // arrived, send our Open as a separate write so it is not coalesced
++                    // with the protocol header.
++                    this.SendOpen(this.deferredOpen);
++                    this.deferredOpen = null;
++                    this.state = ConnectionState.OpenSent;
++                }
+                 else if (this.state == ConnectionState.OpenClosePipe)
+                 {
+                     this.state = ConnectionState.ClosePipe;
+diff --git a/src/Listener/ListenerConnection.cs b/src/Listener/ListenerConnection.cs
+index 631fab7..d297e92 100644
+--- a/src/Listener/ListenerConnection.cs
++++ b/src/Listener/ListenerConnection.cs
+@@ -37,6 +37,14 @@ namespace Amqp.Listener
+             this.listener = listener;
+         }
+ 
++        // Defer the local Open until the client's protocol header is received. Pipelining
++        // the header and Open into one TCP segment breaks some clients (Node rhea), which
++        // intermittently fail to parse the coalesced bytes and hang until their open timeout.
++        internal override bool PipelineOpen
++        {
++            get { return false; }
++        }
++
+         /// <summary>
+         /// Gets a IPrincipal object for the connection. If the value is null,
+         /// the connection is not authenticated.

--- a/patches/amqpnetlite/0002-target-netstandard2.0-only.patch
+++ b/patches/amqpnetlite/0002-target-netstandard2.0-only.patch
@@ -1,0 +1,12 @@
+diff --git a/src/Amqp.csproj b/src/Amqp.csproj
+index b8b44f2..9dbb0c8 100644
+--- a/src/Amqp.csproj
++++ b/src/Amqp.csproj
+@@ -1,6 +1,6 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+-    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
++    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+     <AssemblyName>Amqp.Net</AssemblyName>
+     <PackageId>AmqpNetLite</PackageId>
+     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/patches/amqpnetlite/README.md
+++ b/patches/amqpnetlite/README.md
@@ -1,0 +1,39 @@
+# AMQPNetLite patches
+
+Patches applied to the `external/amqpnetlite` submodule (Azure/amqpnetlite). They are
+applied by [`apply-patches.ps1`](../../apply-patches.ps1) and, for container builds, by the
+[`Dockerfile`](../../Dockerfile). When the submodule is checked out, the root
+[`Directory.Build.props`](../../Directory.Build.props) auto-detects it and builds
+`AlmostServiceBus.Core` against the patched source; otherwise the published `AMQPNetLite`
+NuGet package is used. Set `UseAmqpNetLiteSource=false` to force the package even when the
+submodule is present.
+
+## Patches
+
+### `0001-defer-listener-open-frame.patch`
+
+Defers the listener's AMQP `Open` frame until the peer's protocol header arrives, so the
+header and `Open` are sent as separate writes instead of being coalesced into one TCP
+segment. Some clients — notably the Node.js `@azure/service-bus` / `rhea` client opening
+several connections concurrently — fail to parse the coalesced bytes and hang until their
+connection-open timeout (~60s).
+
+Introduces an internal virtual `Connection.PipelineOpen` (default `true`) that
+`ListenerConnection` overrides to `false`; client connections are unchanged.
+
+**Submitted upstream:** https://github.com/Azure/amqpnetlite/pull/651
+(branch `fix/defer-listener-open-frame`). Once merged and released, this patch and the
+source-build wiring can be dropped in favour of the NuGet package.
+
+### `0002-target-netstandard2.0-only.patch`
+
+Drops the `netstandard1.3` target from `src/Amqp.csproj`, leaving `netstandard2.0`. This
+avoids building the legacy target (which pulls obsolete packages) when compiling the
+vendored source; `AlmostServiceBus.Core` targets `net10.0`, which resolves `netstandard2.0`.
+
+## Regenerating
+
+```bash
+cd external/amqpnetlite
+git diff > ../../patches/amqpnetlite/000X-<name>.patch
+```

--- a/src/AlmostServiceBus.Core/AlmostServiceBus.Core.csproj
+++ b/src/AlmostServiceBus.Core/AlmostServiceBus.Core.csproj
@@ -8,8 +8,11 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="AMQPNetLite" Version="2.5.4" />
+  <ItemGroup Condition="'$(UseAmqpNetLiteSource)' != 'true'">
+    <PackageReference Include="AMQPNetLite" Version="$(AmqpNetLitePackageVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseAmqpNetLiteSource)' == 'true'">
+    <ProjectReference Include="$(AmqpNetLiteSourceProject)" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="AlmostServiceBus.Tests" />

--- a/tests/AlmostServiceBus.MassTransit.Tests/AlmostServiceBus.MassTransit.Tests.csproj
+++ b/tests/AlmostServiceBus.MassTransit.Tests/AlmostServiceBus.MassTransit.Tests.csproj
@@ -12,7 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AMQPNetLite" Version="2.5.4" />
+    <PackageReference Include="AMQPNetLite" Version="$(AmqpNetLitePackageVersion)" Condition="'$(UseAmqpNetLiteSource)' != 'true'" />
+    <ProjectReference Include="$(AmqpNetLiteSourceProject)" Condition="'$(UseAmqpNetLiteSource)' == 'true'" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.2" />
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="MassTransit.Azure.ServiceBus.Core" Version="9.1.2" />

--- a/tests/AlmostServiceBus.SdkIntegration.Tests/AlmostServiceBus.SdkIntegration.Tests.csproj
+++ b/tests/AlmostServiceBus.SdkIntegration.Tests/AlmostServiceBus.SdkIntegration.Tests.csproj
@@ -12,7 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AMQPNetLite" Version="2.5.4" />
+    <PackageReference Include="AMQPNetLite" Version="$(AmqpNetLitePackageVersion)" Condition="'$(UseAmqpNetLiteSource)' != 'true'" />
+    <ProjectReference Include="$(AmqpNetLiteSourceProject)" Condition="'$(UseAmqpNetLiteSource)' == 'true'" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.2" />
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />

--- a/tests/client-sdk-smoke/README.md
+++ b/tests/client-sdk-smoke/README.md
@@ -39,6 +39,7 @@ python smoke.py
 cd tests/client-sdk-smoke/node
 npm ci
 node smoke.mjs
+node concurrent-connections.mjs   # concurrency regression guard, see below
 
 # Java (17+, Maven)
 cd tests/client-sdk-smoke/java
@@ -48,6 +49,22 @@ mvn -q compile exec:java
 `ASB_CONNECTION_STRING` overrides the connection string (default is the emulator's
 `RootManageSharedAccessKey` string with `UseDevelopmentEmulator=true`); `ASB_ADMIN_ENDPOINT`
 overrides the admin API base URL (default `http://localhost:5300`).
+
+## Node.js concurrent-connection regression test
+
+`node/concurrent-connections.mjs` opens **6 clients** (6 AMQP connections) at once, each with
+**4 senders + 4 receivers** sending **10 messages** per sender (240 messages total), and asserts
+they all complete within a wall-clock deadline. It is a regression guard for
+[amqpnetlite PR #651](https://github.com/Azure/amqpnetlite/pull/651): unpatched, the listener
+writes its AMQP `Open` frame before reading the peer's protocol header, and because rhea (the
+Node transport) often coalesces its header and `Open` into one TCP segment, concurrent connects
+deadlock until a ~60s idle timeout — the test fails fast at its 30s deadline. The patched source
+(built via the `external/amqpnetlite` submodule) defers the listener `Open`, so the test passes
+in about a second. Verified both ways: patched → pass, stock NuGet 2.5.4 → deadline failure with
+only 2 of the 6 connections established.
+
+Knobs (all optional): `ASB_CONC_CLIENTS`, `ASB_CONC_LINKS`, `ASB_CONC_MESSAGES`,
+`ASB_CONC_DEADLINE_MS`.
 
 ## Why management goes over plain HTTP, not the SDK admin clients
 

--- a/tests/client-sdk-smoke/node/concurrent-connections.mjs
+++ b/tests/client-sdk-smoke/node/concurrent-connections.mjs
@@ -1,0 +1,175 @@
+// Concurrency stress test: the Node.js Azure Service Bus SDK (@azure/service-bus, rhea transport)
+// opening many AMQP connections at once against a running AlmostServiceBus emulator.
+//
+// This is a regression guard for https://github.com/Azure/amqpnetlite/pull/651. Unpatched,
+// AMQPNetLite's listener writes its AMQP Open frame as soon as the socket is accepted, before it
+// has read the peer's protocol header. rhea frequently coalesces its protocol header and Open into
+// a single TCP segment; when several connections are established concurrently the listener and the
+// client both wait for the other's header, so every connection stalls until a ~60s idle timeout.
+// The patch defers the listener Open until the peer header arrives, so concurrent connects succeed
+// immediately.
+//
+// Scenario: 6 clients (= 6 AMQP connections), each with 4 senders + 4 receivers, 10 messages per
+// sender. All connections are opened concurrently to provoke the race. A hard wall-clock deadline
+// turns the unpatched hang into a fast, clear failure instead of a multi-minute stall.
+//
+//   ASB_CONNECTION_STRING=... ASB_ADMIN_ENDPOINT=http://localhost:5300 node concurrent-connections.mjs
+
+import { ServiceBusClient } from "@azure/service-bus";
+import { randomUUID } from "node:crypto";
+
+const CONNECTION_STRING =
+  process.env.ASB_CONNECTION_STRING ??
+  "Endpoint=sb://localhost:5672;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=emulator;UseDevelopmentEmulator=true";
+const ADMIN_ENDPOINT = (process.env.ASB_ADMIN_ENDPOINT ?? "http://localhost:5300").replace(/\/+$/, "");
+
+const CLIENTS = Number(process.env.ASB_CONC_CLIENTS ?? 6);
+const LINKS_PER_CLIENT = Number(process.env.ASB_CONC_LINKS ?? 4);
+const MESSAGES_PER_SENDER = Number(process.env.ASB_CONC_MESSAGES ?? 10);
+// Comfortably above the patched runtime (a few seconds) and well below the unpatched ~60s idle
+// hang, so this fails fast against an unpatched emulator.
+const DEADLINE_MS = Number(process.env.ASB_CONC_DEADLINE_MS ?? 30_000);
+const RECEIVE_WAIT_MS = 15_000;
+
+const RUN = randomUUID().replace(/-/g, "").slice(0, 8);
+const SB_NS = "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect";
+const queueName = (c, l) => `conc-node-${RUN}-c${c}-q${l}`;
+
+let stepNo = 0;
+const step = (name) => console.log(`[${String(++stepNo).padStart(2, "0")}] ${name}`);
+function check(cond, what) {
+  if (!cond) throw new Error(`check failed: ${what}`);
+  console.log(`    ok   ${what}`);
+}
+
+// ── plain-HTTP management helpers (see smoke.mjs) ─────────────────────────────
+
+function keyName() {
+  const m = /SharedAccessKeyName=([^;]+)/.exec(CONNECTION_STRING);
+  return m ? m[1] : "RootManageSharedAccessKey";
+}
+
+async function mgmt(method, path, body) {
+  const res = await fetch(`${ADMIN_ENDPOINT}/${path}?api-version=2021-05`, {
+    method,
+    headers: {
+      Authorization: `SharedAccessSignature sr=localhost&sig=x&se=1&skn=${keyName()}`,
+      "Content-Type": "application/atom+xml;type=entry;charset=utf-8",
+    },
+    body,
+  });
+  return { status: res.status, text: await res.text() };
+}
+
+const entry = (tag, inner) =>
+  `<entry xmlns="http://www.w3.org/2005/Atom"><content type="application/xml">` +
+  `<${tag} xmlns="${SB_NS}" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">${inner}</${tag}></content></entry>`;
+const created = (r) => r.status === 200 || r.status === 201;
+
+// Reject if the whole scenario has not finished by the deadline. Without this the unpatched hang
+// would keep the process alive for minutes; instead we surface a clear, fast failure.
+function withDeadline(promise, ms) {
+  let timer;
+  const deadline = new Promise((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`deadline of ${ms}ms exceeded — connections did not all open in time ` +
+        `(this is the symptom fixed by amqpnetlite PR #651)`)),
+      ms,
+    );
+  });
+  return Promise.race([promise.finally(() => clearTimeout(timer)), deadline]);
+}
+
+async function receiveExactly(receiver, count, waitMs) {
+  const collected = [];
+  const start = Date.now();
+  while (collected.length < count && Date.now() - start < waitMs) {
+    const batch = await receiver.receiveMessages(count - collected.length, {
+      maxWaitTimeInMs: Math.max(1000, waitMs - (Date.now() - start)),
+    });
+    if (batch.length === 0) break;
+    for (const m of batch) {
+      await receiver.completeMessage(m);
+      collected.push(m);
+    }
+  }
+  return collected;
+}
+
+// One client's whole workload: open its connection, then run all its links concurrently.
+async function runClient(clientIndex) {
+  const client = new ServiceBusClient(CONNECTION_STRING);
+  try {
+    const linkWork = [];
+    for (let l = 0; l < LINKS_PER_CLIENT; l++) {
+      const queue = queueName(clientIndex, l);
+      linkWork.push((async () => {
+        const sender = client.createSender(queue);
+        const receiver = client.createReceiver(queue, { receiveMode: "peekLock" });
+        try {
+          const batch = [];
+          for (let i = 0; i < MESSAGES_PER_SENDER; i++) {
+            batch.push({ body: `c${clientIndex}-q${l}-m${i}`, messageId: `c${clientIndex}-q${l}-m${i}` });
+          }
+          await sender.sendMessages(batch);
+          const got = await receiveExactly(receiver, MESSAGES_PER_SENDER, RECEIVE_WAIT_MS);
+          check(
+            got.length === MESSAGES_PER_SENDER,
+            `client ${clientIndex} queue ${l}: received ${got.length}/${MESSAGES_PER_SENDER}`,
+          );
+          return got.length;
+        } finally {
+          await sender.close();
+          await receiver.close();
+        }
+      })());
+    }
+    const counts = await Promise.all(linkWork);
+    return counts.reduce((a, b) => a + b, 0);
+  } finally {
+    await client.close();
+  }
+}
+
+async function main() {
+  const total = CLIENTS * LINKS_PER_CLIENT * MESSAGES_PER_SENDER;
+  step(`create ${CLIENTS * LINKS_PER_CLIENT} queues (${CLIENTS} clients x ${LINKS_PER_CLIENT} links)`);
+  const creations = [];
+  for (let c = 0; c < CLIENTS; c++) {
+    for (let l = 0; l < LINKS_PER_CLIENT; l++) {
+      creations.push(
+        mgmt("PUT", queueName(c, l), entry("QueueDescription", "<LockDuration>PT1M</LockDuration>")).then((r) =>
+          check(created(r), `create ${queueName(c, l)} -> ${r.status}`),
+        ),
+      );
+    }
+  }
+  await Promise.all(creations);
+
+  step(`open ${CLIENTS} connections concurrently, send/receive ${total} messages`);
+  const started = Date.now();
+  // All clients start at once so their AMQP connections race — this is what triggers the
+  // unpatched listener's coalesced-header deadlock.
+  const perClient = await withDeadline(Promise.all(Array.from({ length: CLIENTS }, (_, c) => runClient(c))), DEADLINE_MS);
+  const received = perClient.reduce((a, b) => a + b, 0);
+  const elapsed = ((Date.now() - started) / 1000).toFixed(1);
+  check(received === total, `received all ${total} messages across ${CLIENTS} concurrent connections (${elapsed}s)`);
+
+  step("delete queues");
+  const deletions = [];
+  for (let c = 0; c < CLIENTS; c++) {
+    for (let l = 0; l < LINKS_PER_CLIENT; l++) {
+      deletions.push(mgmt("DELETE", queueName(c, l)));
+    }
+  }
+  await Promise.all(deletions);
+
+  console.log("\nNode SDK concurrent-connection test passed");
+}
+
+main().catch((err) => {
+  console.error("    FAIL:", err instanceof Error ? err.message : err);
+  // Force exit: on the unpatched hang the stalled SDK connections keep the event loop alive, so
+  // setting process.exitCode alone would never let the process terminate.
+  process.exit(1);
+});

--- a/tests/client-sdk-smoke/node/package.json
+++ b/tests/client-sdk-smoke/node/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "description": "Smoke test of @azure/service-bus against a running AlmostServiceBus emulator",
   "scripts": {
-    "smoke": "node smoke.mjs"
+    "smoke": "node smoke.mjs",
+    "concurrent": "node concurrent-connections.mjs"
   },
   "dependencies": {
     "@azure/service-bus": "^7.9.5"


### PR DESCRIPTION
# Build the AMQPNetLite listener-concurrency fix from source

> **⚠️ Depends on the earlier Docker PR — merge that one first.** This PR builds on the Docker
> support introduced previously; it should only be merged after that PR has landed.

## Summary

Wires in an optional build-from-source path for [AMQPNetLite](https://github.com/Azure/amqpnetlite) so the emulator can ship the fix from **[Azure/amqpnetlite#651](https://github.com/Azure/amqpnetlite/pull/651)** ahead of an upstream release, and adds a Node.js concurrency regression test that guards it.

## Motivation

The Node.js SDK (`@azure/service-bus`, rhea transport) hangs for ~60s when several AMQP connections are opened concurrently against the emulator. Root cause is in AMQPNetLite's listener: it writes its AMQP `Open` frame as soon as the socket is accepted, **before** reading the peer's protocol header. rhea frequently coalesces its protocol header and `Open` into a single TCP segment, so under concurrent connects both sides wait for the other's header until an idle timeout fires.

The fix is upstream in [Azure/amqpnetlite#651](https://github.com/Azure/amqpnetlite/pull/651) ("Listener: defer Open frame until peer protocol header is received") but not yet released. Rather than wait, this PR builds AMQPNetLite from a pinned, patched submodule when it's present.

## Changes

### AMQPNetLite patched-source build path
- Added `external/amqpnetlite` as a git submodule (`ignore = dirty`), pinned to a known-good commit.
- Two patches under `patches/amqpnetlite/` applied at build time (never committed into the submodule), mirroring the existing MassTransit/Wolverine model:
  - `0001-defer-listener-open-frame.patch` — the PR #651 fix.
  - `0002-target-netstandard2.0-only.patch` — trims the build to the target we consume.
- `Directory.Build.props` auto-detects the submodule and sets `UseAmqpNetLiteSource=true`; `AlmostServiceBus.Core` (and the SDK/MassTransit test projects) then swap their `PackageReference` for a `ProjectReference`. With the submodule absent, the build falls back to the stock **AMQPNetLite 2.5.4** NuGet package.
- `patches/amqpnetlite/README.md` documents both patches, the PR #651 link, detection, and regeneration.

> **Note:** the published NuGet package still depends on stock AMQPNetLite 2.5.4. The patched source is only used when the submodule is checked out (CI smoke tests and container builds), until PR #651 ships upstream.

### CI
- The `client-sdk-smoke` job now initialises the submodule and applies the patches before building, so it exercises the patched listener.

### Concurrency regression test
- `tests/client-sdk-smoke/node/concurrent-connections.mjs`: opens **6 clients** (6 AMQP connections) at once, each with **4 senders + 4 receivers**, **10 messages per sender** (240 total), and asserts completion within a 30s deadline. Added to CI and documented in the smoke-test README.

## Verification

- `dotnet build AlmostServiceBus.sln` against the patched source — 0 warnings / 0 errors.
- Unit suite: **231/231** pass against the source-built `Amqp.Net.dll`.
- Concurrent-connection test, both directions:

  | AMQPNetLite build | Result |
  |---|---|
  | Patched source (PR #651) | ✅ 240/240 messages, 6/6 connections, exit 0 in ~0.1s |
  | Stock NuGet 2.5.4 | ❌ only 2/6 connections opened, deadline failure, exit 1 |

## References
- Upstream fix: [Azure/amqpnetlite#651](https://github.com/Azure/amqpnetlite/pull/651)
- **Prerequisite:** the earlier Docker support PR (must be merged before this one).