### PR TITLE
Detect AMQP batch transfers by message-format, not by a missing Subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project follows
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **Batch sends from the Node.js SDK lost all but a garbled first message.** A
+  batch is one AMQP transfer whose body is a list of encoded messages. The
+  emulator recognised it only when the envelope had no `Subject`, which holds
+  for the .NET SDK but not for `@azure/service-bus`, whose `sendMessages(array)`
+  copies the first message's properties onto the envelope. Batches are now
+  detected by the transfer's message-format (`0x80013700`), which every SDK
+  sets. The Node.js, Python and Java smoke tests each gained a subject-bearing
+  batch step.
+
 ## [0.5.0] - 2026-09-10
 
 ### Added

--- a/src/AlmostServiceBus.Core/Amqp/SenderLinkEndpoint.cs
+++ b/src/AlmostServiceBus.Core/Amqp/SenderLinkEndpoint.cs
@@ -42,11 +42,10 @@ public class SenderLinkEndpoint : LinkEndpoint
             var rawMsg = messageContext.Message;
 
             // Decode the incoming transfer into one or more brokered messages. The Azure
-            // SDK's ServiceBusMessageBatch arrives as a single transfer whose body is a
-            // Data[] of complete AMQP-encoded inner messages (wrapper has no Subject).
+            // SDKs' message batch arrives as a single transfer whose body is a Data[] of
+            // complete AMQP-encoded inner messages.
             var brokeredMessages = new List<BrokeredMessage>();
-            if (rawMsg.Body is Data[] dataArray && dataArray.Length > 0
-                && rawMsg.Properties?.Subject is null)
+            if (IsBatchTransfer(rawMsg, out var dataArray))
             {
                 Log.LogDebug("RECV BATCH ({Count} messages) → '{Address}'", dataArray.Length, _address);
                 foreach (var data in dataArray)
@@ -167,6 +166,33 @@ public class SenderLinkEndpoint : LinkEndpoint
     /// Converts an AMQP message to a <see cref="BrokeredMessage"/>.
     /// Exposed as public for testing.
     /// </summary>
+    /// <summary>
+    /// AMQP message-format for a Service Bus batch (a transfer carrying several complete
+    /// messages as Data sections). Every Azure SDK stamps it on the transfer.
+    /// </summary>
+    internal const uint BatchMessageFormat = 0x80013700;
+
+    /// <summary>
+    /// Decides whether a transfer is a batch envelope rather than one message.
+    /// The transfer's message-format is authoritative. The body-shape check is kept as a
+    /// fallback for clients that hand-roll batches without setting the format. It must
+    /// not look at the envelope's Properties: the .NET SDK sends a bare envelope, but the
+    /// Node.js SDK copies the first message's properties (Subject included) onto it, and
+    /// an envelope with a Subject was previously mistaken for a single message whose
+    /// body was the raw encoded batch.
+    /// </summary>
+    internal static bool IsBatchTransfer(Message message, out Data[] sections)
+    {
+        if (message.Body is Data[] { Length: > 0 } dataArray)
+        {
+            sections = dataArray;
+            return message.Format == BatchMessageFormat || message.Properties?.Subject is null;
+        }
+
+        sections = [];
+        return false;
+    }
+
     public static BrokeredMessage ConvertToBrokeredMessage(Message amqpMessage)
     {
         var brokered = new BrokeredMessage();

--- a/tests/AlmostServiceBus.SdkIntegration.Tests/BatchEnvelopeTests.cs
+++ b/tests/AlmostServiceBus.SdkIntegration.Tests/BatchEnvelopeTests.cs
@@ -1,0 +1,66 @@
+using Amqp;
+using Amqp.Framing;
+using Azure.Messaging.ServiceBus;
+using AlmostServiceBus.TestHost;
+
+namespace AlmostServiceBus.SdkIntegration.Tests;
+
+/// <summary>
+/// A Service Bus batch is one AMQP transfer (message-format 0x80013700) whose body is a
+/// Data[] of complete encoded messages. The .NET SDK sends a bare envelope, but the
+/// Node.js SDK copies the first message's properties (Subject included) onto it. The
+/// emulator used to recognise a batch only by the envelope having no Subject, so a
+/// Node.js batch became a single message whose body was the raw encoded batch.
+/// </summary>
+public class BatchEnvelopeTests : IAsyncLifetime
+{
+    private readonly ServiceBusEmulatorFixture _fixture = new();
+
+    public async Task InitializeAsync() => await _fixture.StartAsync();
+    public async Task DisposeAsync() => await _fixture.DisposeAsync();
+
+    [Fact]
+    public async Task BatchEnvelopeWithSubject_IsUnpackedIntoIndividualMessages()
+    {
+        const string queue = "batch-envelope-subject";
+        _fixture.GetDefaultNamespaceContext().CreateQueue(queue);
+
+        var address = new Address("localhost", _fixture.PublicPort, null, null, "/", "AMQP");
+        var factory = new ConnectionFactory();
+        factory.SASL.Profile = Amqp.Sasl.SaslProfile.Anonymous;
+        var connection = await factory.CreateAsync(address);
+        var session = new Session(connection);
+        var sender = new SenderLink(session, "batch-envelope-sender", queue);
+
+        // Three complete messages, each with its own Subject, packed as consecutive Data
+        // sections the way rhea does it.
+        var sections = new DataList();
+        foreach (var (body, subject) in new[] { ("b1", "OrderPlaced"), ("b2", "OrderPlaced"), ("b3", "OrderShipped") })
+        {
+            var inner = new Message(new Data { Binary = System.Text.Encoding.UTF8.GetBytes(body) })
+            {
+                Properties = new Properties { MessageId = body, Subject = subject },
+            };
+            var encoded = inner.Encode();
+            sections.Add(new Data { Binary = encoded.Buffer.AsSpan(encoded.Offset, encoded.Length).ToArray() });
+        }
+
+        var envelope = new Message
+        {
+            Format = 0x80013700,
+            BodySection = sections,
+            // What the Node.js SDK does: the first message's properties end up on the envelope.
+            Properties = new Properties { MessageId = "b1", Subject = "OrderPlaced" },
+        };
+        await sender.SendAsync(envelope);
+        await connection.CloseAsync();
+
+        var cs = $"Endpoint=sb://localhost:{_fixture.PublicPort};SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=emulator;UseDevelopmentEmulator=true";
+        await using var client = new ServiceBusClient(cs);
+        var receiver = client.CreateReceiver(queue);
+        var received = await receiver.ReceiveMessagesAsync(5, TimeSpan.FromSeconds(5));
+
+        Assert.Equal(["b1", "b2", "b3"], received.Select(m => m.Body.ToString()).ToArray());
+        Assert.Equal(["OrderPlaced", "OrderPlaced", "OrderShipped"], received.Select(m => m.Subject).ToArray());
+    }
+}

--- a/tests/client-sdk-smoke/java/src/main/java/io/almostservicebus/smoke/Smoke.java
+++ b/tests/client-sdk-smoke/java/src/main/java/io/almostservicebus/smoke/Smoke.java
@@ -169,6 +169,19 @@ public final class Smoke {
             receiver.peekMessages(5).forEach(empty::add);
             check(empty.isEmpty(), "queue empty after completing both");
 
+            step("batch send where the first message has a subject");
+            sender.sendMessages(List.of(
+                new ServiceBusMessage("b1").setSubject("OrderPlaced"),
+                new ServiceBusMessage("b2").setSubject("OrderPlaced"),
+                new ServiceBusMessage("b3").setSubject("OrderShipped")));
+            List<ServiceBusReceivedMessage> batch = new ArrayList<>();
+            receiver.receiveMessages(5, WAIT).forEach(batch::add);
+            check(batch.size() == 3, "all three batched messages arrive as separate messages (" + batch.size() + ")");
+            List<String> bodies = batch.stream().map(x -> x.getBody().toString()).toList();
+            check(List.of("b1", "b2", "b3").equals(bodies), "bodies intact (" + bodies + ")");
+            check("OrderShipped".equals(batch.get(2).getSubject()), "each message keeps its own subject");
+            for (ServiceBusReceivedMessage x : batch) receiver.complete(x);
+
             step("abandon -> redelivery bumps deliveryCount");
             sender.sendMessage(new ServiceBusMessage("retry-me"));
             ServiceBusReceivedMessage first = receiveOne(receiver);

--- a/tests/client-sdk-smoke/node/smoke.mjs
+++ b/tests/client-sdk-smoke/node/smoke.mjs
@@ -125,6 +125,21 @@ async function main() {
     for (let i = 0; i < 2; i++) await receiver.completeMessage(await receiveOne(receiver));
     check((await receiver.peekMessages(5)).length === 0, "queue empty after completing both");
 
+    step("batch send where the first message has a subject");
+    // sendMessages(array) builds one AMQP batch transfer. The Node SDK copies the first
+    // message's properties (subject included) onto the batch envelope, which used to make the
+    // emulator treat the whole batch as a single message.
+    await sender.sendMessages([
+      { body: "b1", subject: "OrderPlaced", applicationProperties: { n: 1 } },
+      { body: "b2", subject: "OrderPlaced", applicationProperties: { n: 2 } },
+      { body: "b3", subject: "OrderShipped", applicationProperties: { n: 3 } },
+    ]);
+    const batch = await receiver.receiveMessages(5, { maxWaitTimeInMs: WAIT_MS });
+    check(batch.length === 3, `all three batched messages arrive as separate messages (${batch.length})`);
+    check(batch.map((m) => m.body).join() === "b1,b2,b3", `bodies intact (${batch.map((m) => m.body)})`);
+    check(batch[2].subject === "OrderShipped" && batch[2].applicationProperties?.n === 3, "each message keeps its own subject and properties");
+    for (const m of batch) await receiver.completeMessage(m);
+
     step("abandon -> redelivery bumps deliveryCount");
     await sender.sendMessages({ body: "retry-me" });
     const first = await receiveOne(receiver);

--- a/tests/client-sdk-smoke/python/smoke.py
+++ b/tests/client-sdk-smoke/python/smoke.py
@@ -181,6 +181,20 @@ def main():
                 receiver.complete_message(receive_one(receiver))
             check(len(receiver.peek_messages(max_message_count=5)) == 0, "queue empty after completing both")
 
+            step("batch send where the first message has a subject")
+            with client.get_queue_sender(QUEUE) as sender:
+                sender.send_messages([
+                    ServiceBusMessage("b1", subject="OrderPlaced", application_properties={"n": 1}),
+                    ServiceBusMessage("b2", subject="OrderPlaced", application_properties={"n": 2}),
+                    ServiceBusMessage("b3", subject="OrderShipped", application_properties={"n": 3}),
+                ])
+            batch = receiver.receive_messages(max_message_count=5, max_wait_time=WAIT)
+            check(len(batch) == 3, f"all three batched messages arrive as separate messages ({len(batch)})")
+            check([str(m) for m in batch] == ["b1", "b2", "b3"], f"bodies intact ({[str(m) for m in batch]})")
+            check(batch[2].subject == "OrderShipped" and batch[2].application_properties[b"n"] == 3, "each message keeps its own subject and properties")
+            for m in batch:
+                receiver.complete_message(m)
+
             step("abandon -> redelivery bumps delivery_count")
             with client.get_queue_sender(QUEUE) as sender:
                 sender.send_messages(ServiceBusMessage("retry-me"))


### PR DESCRIPTION
## What

`@azure/service-bus` `sendMessages(array)` against the emulator stored **one garbled message instead of N** whenever the first message had a `subject`.

## Why

A batch is a single AMQP transfer with message-format `0x80013700` whose body is a `Data[]` of complete encoded messages. `SenderLinkEndpoint` recognised a batch only when the envelope had no `Subject`. The .NET SDK sends a bare envelope so that worked; the Node.js SDK copies the first message's `properties` (subject included) onto the batch envelope, so the batch was treated as one ordinary message whose body was the raw encoded payload. Python (pyamqp) does not copy properties, which is why the existing Python and Node smoke steps (subject-less batches) never caught it.

## Fix

Detect batches by `Message.Format == 0x80013700`, which every SDK stamps on the transfer. The body-shape check stays as a fallback for hand-rolled batches without a format.

## Tests

- `BatchEnvelopeTests` (SDK integration): raw AMQPNetLite client sends a subject-bearing batch envelope; asserts three separate messages with their own subjects. Fails on `main`, passes here.
- Node.js, Python and Java smoke tests each gain a "batch send where the first message has a subject" step. All three pass locally against this branch.
- Unit 234/234, SDK integration 52/52.

CHANGELOG has an `[Unreleased]` entry for 0.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
