### PR TITLE
Dashboard API: one route per operation instead of catch-all path inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,17 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
-### Fixed
-- **Batch sends from the Node.js SDK lost all but a garbled first message.** A
+### Changed
+- **Dashboard API routes are one route per operation.** The dashboard's JSON
+  API used catch-all routes (`/queues/{**path}`) that inspected the tail of the
+  path to decide between `/messages`, `/deadletter` and `/properties`. Each
+  operation is now its own route, with subscriptions addressed as
+  `/topics/{topic}/subscriptions/{subscription}/...`. Entity names, which may
+  contain slashes, travel percent-encoded as a single path segment
+  (`orders%2Feu` rather than `orders/eu`). The dashboard was updated to match;
+  scripts that call the API directly need the same encoding.
+
+### Fixed- **Batch sends from the Node.js SDK lost all but a garbled first message.** A
   batch is one AMQP transfer whose body is a list of encoded messages. The
   emulator recognised it only when the envelope had no `Subject`, which holds
   for the .NET SDK but not for `@azure/service-bus`, whose `sendMessages(array)`
@@ -50,6 +59,9 @@ All notable changes to this project are documented here. The format is based on
   plaintext endpoint. Writing them surfaced the five protocol fixes below.
 
 ### Fixed
+- **Dashboard purge endpoints now actually remove messages.** `DELETE .../messages`
+  and `DELETE .../deadletter` only locked the messages, so they reappeared with a
+  higher delivery count once the lock expired. They are now completed.
 - **Node.js connections hung for ~60 s when several were opened at once.**
   AMQPNetLite's listener pipelines its AMQP header and `open` straight after
   the `sasl-outcome`; rhea (the Node transport) stops parsing at the

--- a/src/AlmostServiceBus.Core/Dashboard/DashboardApiEndpoints.cs
+++ b/src/AlmostServiceBus.Core/Dashboard/DashboardApiEndpoints.cs
@@ -2,25 +2,76 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Routing;
 using AlmostServiceBus.Core.Broker;
 
 namespace AlmostServiceBus.Core.Dashboard;
 
+/// <summary>
+/// JSON API behind the Vue dashboard. One route per operation:
+/// <code>
+/// GET    /api/dashboard/info
+/// GET    /api/dashboard/namespaces
+/// GET    /api/dashboard/namespaces/{ns}/entities
+/// GET    /api/dashboard/namespaces/{ns}/queues/{queue}/messages
+/// GET    /api/dashboard/namespaces/{ns}/queues/{queue}/deadletter
+/// GET    /api/dashboard/namespaces/{ns}/queues/{queue}/properties
+/// DELETE /api/dashboard/namespaces/{ns}/queues/{queue}/messages
+/// DELETE /api/dashboard/namespaces/{ns}/queues/{queue}/deadletter
+/// GET    /api/dashboard/namespaces/{ns}/topics/{topic}/messages
+/// GET    /api/dashboard/namespaces/{ns}/topics/{topic}/subscriptions/{subscription}/messages
+/// GET    /api/dashboard/namespaces/{ns}/topics/{topic}/subscriptions/{subscription}/deadletter
+/// DELETE /api/dashboard/namespaces/{ns}/topics/{topic}/subscriptions/{subscription}/messages
+/// DELETE /api/dashboard/namespaces/{ns}/topics/{topic}/subscriptions/{subscription}/deadletter
+/// GET    /api/dashboard/diagnostics
+/// </code>
+/// Entity names may contain slashes (MassTransit and Wolverine both produce hierarchical
+/// names), so they travel percent-encoded as a single path segment; see <see cref="EntityName"/>.
+/// </summary>
 public static class DashboardApiEndpoints
 {
+    private const int PeekLimit = 50;
+
     public static IEndpointRouteBuilder MapDashboardApi(
         this IEndpointRouteBuilder app,
         NamespaceRegistry registry,
         EmulatorInfo info)
     {
         var api = app.MapGroup("/api/dashboard");
+        api.MapGet("/info", () => info);
+        api.MapGet("/namespaces", ListNamespaces);
+        api.MapGet("/diagnostics", Diagnostics);
 
-        api.MapGet("/info", () => Results.Ok(info));
+        var namespaceGroup = api.MapGroup("/namespaces/{ns}");
+        namespaceGroup.MapGet("/entities", Entities);
 
-        api.MapGet("/namespaces", () =>
-        {
-            return registry.ListNamespaces().Select(name =>
+        var queueGroup = namespaceGroup.MapGroup("/queues/{queue}");
+        queueGroup.MapGet("/messages", (string ns, EntityName queue) => Peek(FindQueue(ns, queue)));
+        queueGroup.MapGet("/deadletter", (string ns, EntityName queue) => Peek(FindQueue(ns, queue)?.DeadLetterQueue));
+        queueGroup.MapGet("/properties", QueuePropertiesOf);
+        queueGroup.MapDelete("/messages", (string ns, EntityName queue) => Purge(FindQueue(ns, queue)));
+        queueGroup.MapDelete("/deadletter", (string ns, EntityName queue) => Purge(FindQueue(ns, queue)?.DeadLetterQueue));
+
+        var topicGroup = namespaceGroup.MapGroup("/topics/{topic}");
+        topicGroup.MapGet("/messages", TopicMessages);
+
+        var subscriptionGroup = topicGroup.MapGroup("/subscriptions/{subscription}");
+        subscriptionGroup.MapGet("/messages", (string ns, EntityName topic, EntityName subscription) =>
+            Peek(FindSubscription(ns, topic, subscription)?.Queue));
+        subscriptionGroup.MapGet("/deadletter", (string ns, EntityName topic, EntityName subscription) =>
+            Peek(FindSubscription(ns, topic, subscription)?.Queue.DeadLetterQueue));
+        subscriptionGroup.MapDelete("/messages", (string ns, EntityName topic, EntityName subscription) =>
+            Purge(FindSubscription(ns, topic, subscription)?.Queue));
+        subscriptionGroup.MapDelete("/deadletter", (string ns, EntityName topic, EntityName subscription) =>
+            Purge(FindSubscription(ns, topic, subscription)?.Queue.DeadLetterQueue));
+
+        return app;
+
+        // ── handlers ─────────────────────────────────────────────────────────
+
+        List<NamespaceInfo> ListNamespaces() =>
+            registry.ListNamespaces().Select(name =>
             {
                 var ns = registry.Get(name);
                 return new NamespaceInfo(
@@ -29,12 +80,11 @@ public static class DashboardApiEndpoints
                     ns?.GetTopics().Count ?? 0,
                     ns?.LastActivityAt ?? DateTimeOffset.MinValue);
             }).ToList();
-        });
 
-        api.MapGet("/namespaces/{ns}/entities", (string ns) =>
+        Results<Ok<EntityOverview>, NotFound> Entities(string ns)
         {
             var context = registry.Get(ns);
-            if (context is null) return Results.NotFound();
+            if (context is null) return TypedResults.NotFound();
 
             var queues = context.GetQueues().Select(q => new QueueInfo(
                 q.Name, q.MessageCount, q.DeadLetterQueue.MessageCount,
@@ -49,178 +99,75 @@ public static class DashboardApiEndpoints
                     s.GetRules().Count)).ToList()
             )).ToList();
 
-            return Results.Ok(new EntityOverview(queues, topics));
-        });
+            return TypedResults.Ok(new EntityOverview(queues, topics));
+        }
 
-        // Catch-all GET for queue messages and deadletter peek.
-        // The {**path} captures "queueName/messages" or "queueName/deadletter".
-        api.MapGet("/namespaces/{ns}/queues/{**path}", (string ns, string path) =>
+        Results<Ok<QueueProperties>, NotFound> QueuePropertiesOf(string ns, EntityName queue) =>
+            FindQueue(ns, queue) is { } q ? TypedResults.Ok(ToQueueProperties(q)) : TypedResults.NotFound();
+
+        // A topic holds no messages itself; show the newest across all its subscriptions.
+        Results<Ok<List<MessageInfo>>, NotFound> TopicMessages(string ns, EntityName topic)
         {
-            var context = registry.Get(ns);
-            if (context is null) return Results.NotFound();
+            var entity = registry.Get(ns)?.GetTopic(topic.Value);
+            if (entity is null) return TypedResults.NotFound();
 
-            if (path.EndsWith("/messages", StringComparison.OrdinalIgnoreCase))
-            {
-                var queueName = path[..^"/messages".Length];
-                var queue = context.GetQueue(queueName);
-                if (queue is null) return Results.NotFound();
-                return Results.Ok(queue.PeekMessages(50).Select(ToMessageInfo).ToList());
-            }
+            var messages = entity.GetSubscriptions()
+                .SelectMany(s => s.Queue.PeekMessages(PeekLimit))
+                .OrderByDescending(m => m.SequenceNumber)
+                .Take(PeekLimit)
+                .Select(ToMessageInfo)
+                .ToList();
+            return TypedResults.Ok(messages);
+        }
 
-            if (path.EndsWith("/deadletter", StringComparison.OrdinalIgnoreCase))
-            {
-                var queueName = path[..^"/deadletter".Length];
-                var queue = context.GetQueue(queueName);
-                if (queue is null) return Results.NotFound();
-                return Results.Ok(queue.DeadLetterQueue.PeekMessages(50).Select(ToMessageInfo).ToList());
-            }
+        QueueEntity? FindQueue(string ns, EntityName queue) =>
+            registry.Get(ns)?.GetQueue(queue.Value);
 
-            if (path.EndsWith("/properties", StringComparison.OrdinalIgnoreCase))
-            {
-                var queueName = path[..^"/properties".Length];
-                var queue = context.GetQueue(queueName);
-                if (queue is null) return Results.NotFound();
-                return Results.Ok(ToQueueProperties(queue));
-            }
-
-            return Results.NotFound();
-        });
-
-        // Catch-all GET for topic subscription messages.
-        api.MapGet("/namespaces/{ns}/topics/{**path}", (string ns, string path) =>
-        {
-            var context = registry.Get(ns);
-            if (context is null) return Results.NotFound();
-
-            // path = "TopicName/subscriptions/SubName/messages" or ".../deadletter"
-            // or just "TopicName/messages" (peek all subscriptions)
-            if (path.EndsWith("/messages", StringComparison.OrdinalIgnoreCase))
-            {
-                var rest = path[..^"/messages".Length];
-                if (TryParseSubscriptionPath(rest, out var subTopicName, out var subName))
-                {
-                    var sub = context.GetTopic(subTopicName)?.GetSubscription(subName);
-                    if (sub is null) return Results.NotFound();
-                    return Results.Ok(sub.Queue.PeekMessages(50).Select(ToMessageInfo).ToList());
-                }
-
-                var topic = context.GetTopic(rest);
-                if (topic is null) return Results.NotFound();
-
-                // Aggregate messages from all subscriptions' queues
-                var messages = topic.GetSubscriptions()
-                    .SelectMany(s => s.Queue.PeekMessages(50))
-                    .OrderByDescending(m => m.SequenceNumber)
-                    .Take(50)
-                    .Select(ToMessageInfo)
-                    .ToList();
-                return Results.Ok(messages);
-            }
-
-            if (path.EndsWith("/deadletter", StringComparison.OrdinalIgnoreCase))
-            {
-                var rest = path[..^"/deadletter".Length];
-                if (!TryParseSubscriptionPath(rest, out var subTopicName, out var subName))
-                    return Results.NotFound();
-
-                var sub = context.GetTopic(subTopicName)?.GetSubscription(subName);
-                if (sub is null) return Results.NotFound();
-                return Results.Ok(sub.Queue.DeadLetterQueue.PeekMessages(50).Select(ToMessageInfo).ToList());
-            }
-
-            return Results.NotFound();
-        });
-
-        // Catch-all DELETE for queue purge operations.
-        api.MapDelete("/namespaces/{ns}/queues/{**path}", (string ns, string path) =>
-        {
-            var context = registry.Get(ns);
-            if (context is null) return Results.NotFound();
-
-            if (path.EndsWith("/messages", StringComparison.OrdinalIgnoreCase))
-            {
-                var queueName = path[..^"/messages".Length];
-                var queue = context.GetQueue(queueName);
-                if (queue is null) return Results.NotFound();
-                while (queue.TryDequeueImmediate() is not null) { }
-                return Results.Ok();
-            }
-
-            if (path.EndsWith("/deadletter", StringComparison.OrdinalIgnoreCase))
-            {
-                var queueName = path[..^"/deadletter".Length];
-                var queue = context.GetQueue(queueName);
-                if (queue is null) return Results.NotFound();
-                while (queue.DeadLetterQueue.TryDequeueImmediate() is not null) { }
-                return Results.Ok();
-            }
-
-            return Results.NotFound();
-        });
-
-        // Catch-all DELETE for subscription purge operations.
-        api.MapDelete("/namespaces/{ns}/topics/{**path}", (string ns, string path) =>
-        {
-            var context = registry.Get(ns);
-            if (context is null) return Results.NotFound();
-
-            if (path.EndsWith("/messages", StringComparison.OrdinalIgnoreCase))
-            {
-                var rest = path[..^"/messages".Length];
-                if (!TryParseSubscriptionPath(rest, out var topicName, out var subName))
-                    return Results.NotFound();
-
-                var sub = context.GetTopic(topicName)?.GetSubscription(subName);
-                if (sub is null) return Results.NotFound();
-                while (sub.Queue.TryDequeueImmediate() is not null) { }
-                return Results.Ok();
-            }
-
-            if (path.EndsWith("/deadletter", StringComparison.OrdinalIgnoreCase))
-            {
-                var rest = path[..^"/deadletter".Length];
-                if (!TryParseSubscriptionPath(rest, out var topicName, out var subName))
-                    return Results.NotFound();
-
-                var sub = context.GetTopic(topicName)?.GetSubscription(subName);
-                if (sub is null) return Results.NotFound();
-                while (sub.Queue.DeadLetterQueue.TryDequeueImmediate() is not null) { }
-                return Results.Ok();
-            }
-
-            return Results.NotFound();
-        });
-
-        api.MapGet("/diagnostics", () =>
-        {
-            ThreadPool.GetAvailableThreads(out var workerAvail, out var ioAvail);
-            ThreadPool.GetMaxThreads(out var workerMax, out var ioMax);
-            ThreadPool.GetMinThreads(out var workerMin, out var ioMin);
-            var pending = ThreadPool.PendingWorkItemCount;
-            var threadCount = ThreadPool.ThreadCount;
-
-            return new
-            {
-                threadPool = new
-                {
-                    workerThreads = new { available = workerAvail, max = workerMax, min = workerMin, inUse = workerMax - workerAvail },
-                    ioThreads = new { available = ioAvail, max = ioMax, min = ioMin, inUse = ioMax - ioAvail },
-                    pendingWorkItems = pending,
-                    threadCount,
-                },
-                process = new
-                {
-                    workingSetMB = Environment.WorkingSet / (1024 * 1024),
-                    gcTotalMemoryMB = GC.GetTotalMemory(false) / (1024 * 1024),
-                    gen0Collections = GC.CollectionCount(0),
-                    gen1Collections = GC.CollectionCount(1),
-                    gen2Collections = GC.CollectionCount(2),
-                },
-            };
-        });
-
-        return app;
+        SubscriptionEntity? FindSubscription(string ns, EntityName topic, EntityName subscription) =>
+            registry.Get(ns)?.GetTopic(topic.Value)?.GetSubscription(subscription.Value);
     }
+
+    private static Results<Ok<List<MessageInfo>>, NotFound> Peek(QueueEntity? queue) =>
+        queue is null
+            ? TypedResults.NotFound()
+            : TypedResults.Ok(queue.PeekMessages(PeekLimit).Select(ToMessageInfo).ToList());
+
+    private static Results<Ok, NotFound> Purge(QueueEntity? queue)
+    {
+        if (queue is null) return TypedResults.NotFound();
+        // Receive-and-delete every active message. Locking alone (the old behaviour) only hid
+        // them until the lock expired, after which they came back with a higher delivery count.
+        while (queue.TryDequeueImmediate() is { LockToken: { } lockToken }) queue.Complete(lockToken);
+        return TypedResults.Ok();
+    }
+
+    private static object Diagnostics()
+    {
+        ThreadPool.GetAvailableThreads(out var workerAvail, out var ioAvail);
+        ThreadPool.GetMaxThreads(out var workerMax, out var ioMax);
+        ThreadPool.GetMinThreads(out var workerMin, out var ioMin);
+
+        return new
+        {
+            threadPool = new
+            {
+                workerThreads = new { available = workerAvail, max = workerMax, min = workerMin, inUse = workerMax - workerAvail },
+                ioThreads = new { available = ioAvail, max = ioMax, min = ioMin, inUse = ioMax - ioAvail },
+                pendingWorkItems = ThreadPool.PendingWorkItemCount,
+                threadCount = ThreadPool.ThreadCount,
+            },
+            process = new
+            {
+                workingSetMB = Environment.WorkingSet / (1024 * 1024),
+                gcTotalMemoryMB = GC.GetTotalMemory(false) / (1024 * 1024),
+                gen0Collections = GC.CollectionCount(0),
+                gen1Collections = GC.CollectionCount(1),
+                gen2Collections = GC.CollectionCount(2),
+            },
+        };
+    }
+
+    // ── projections ──────────────────────────────────────────────────────────
 
     private static MessageInfo ToMessageInfo(BrokeredMessage m)
     {
@@ -267,26 +214,6 @@ public static class DashboardApiEndpoints
     private static string? Duration(TimeSpan ts) =>
         ts == TimeSpan.MaxValue ? null : System.Xml.XmlConvert.ToString(ts);
 
-    /// <summary>
-    /// Splits a "TopicName/subscriptions/SubName" dashboard path into its parts.
-    /// Returns <see langword="false"/> for a plain topic path with no subscription segment.
-    /// </summary>
-    private static bool TryParseSubscriptionPath(string path, out string topicName, out string subscriptionName)
-    {
-        const string marker = "/subscriptions/";
-        var idx = path.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
-        if (idx < 0)
-        {
-            topicName = "";
-            subscriptionName = "";
-            return false;
-        }
-
-        topicName = path[..idx];
-        subscriptionName = path[(idx + marker.Length)..];
-        return topicName.Length > 0 && subscriptionName.Length > 0;
-    }
-
     private static Dictionary<string, object>? ExtractScalars(string json)
     {
         try
@@ -309,4 +236,26 @@ public static class DashboardApiEndpoints
         }
         catch { return null; }
     }
+}
+
+/// <summary>
+/// A dashboard route parameter holding a queue, topic or subscription name.
+/// </summary>
+/// <remarks>
+/// Service Bus names can contain <c>/</c>. The dashboard sends them percent-encoded so a whole
+/// name occupies one path segment, which is what lets each operation be its own route instead
+/// of a catch-all that inspects the tail of the path. Kestrel deliberately leaves <c>%2F</c>
+/// encoded (decoding it would change the segment structure of the path) and routing passes it
+/// through untouched, so this is the one place it is turned back into a slash. Service Bus names
+/// cannot contain <c>%</c>, so the replacement is unambiguous.
+/// </remarks>
+internal readonly record struct EntityName(string Value)
+{
+    public static bool TryParse(string? text, out EntityName result)
+    {
+        result = new EntityName((text ?? string.Empty).Replace("%2F", "/", StringComparison.OrdinalIgnoreCase));
+        return text is { Length: > 0 };
+    }
+
+    public override string ToString() => Value;
 }

--- a/src/AlmostServiceBus.Dashboard/src/api/client.ts
+++ b/src/AlmostServiceBus.Dashboard/src/api/client.ts
@@ -14,14 +14,26 @@ async function del(path: string): Promise<void> {
 }
 
 /**
- * Encodes a dynamic path segment while preserving literal "/" separators —
- * entity names here are legitimately hierarchical (topic grouping prefixes,
- * "topic/subscriptions/sub" composite paths), and the backend's {**path}
- * catch-all routes match on raw slashes, so a blanket encodeURIComponent
- * would break routing.
+ * Entity names are hierarchical ("OrderFlowDemo/Contracts/OrderSubmitted") but each name is a
+ * single segment of the API route, so its slashes travel as %2F. encodeURIComponent does that.
  */
-function encodePath(segment: string): string {
-  return segment.split('/').map(encodeURIComponent).join('/')
+const seg = encodeURIComponent
+
+const queueUrl = (ns: string, queue: string) => `/namespaces/${seg(ns)}/queues/${seg(queue)}`
+const topicUrl = (ns: string, topic: string) => `/namespaces/${seg(ns)}/topics/${seg(topic)}`
+
+/**
+ * The dashboard tracks a subscription as the composite "topicName/subscriptions/subName" path
+ * (the same address the SDK uses). The API addresses it as two segments. Subscription names
+ * cannot contain "/", so the last "/subscriptions/" marker is the split point.
+ */
+function subscriptionUrl(ns: string, entityPath: string): string {
+  const marker = '/subscriptions/'
+  const idx = entityPath.lastIndexOf(marker)
+  if (idx < 0) throw new Error(`not a subscription path: ${entityPath}`)
+  const topic = entityPath.slice(0, idx)
+  const subscription = entityPath.slice(idx + marker.length)
+  return `${topicUrl(ns, topic)}/subscriptions/${seg(subscription)}`
 }
 
 export const api = {
@@ -29,33 +41,28 @@ export const api = {
 
   getNamespaces: () => get<NamespaceInfo[]>('/namespaces'),
 
-  getEntities: (ns: string) => get<EntityOverview>(`/namespaces/${encodePath(ns)}/entities`),
+  getEntities: (ns: string) => get<EntityOverview>(`/namespaces/${seg(ns)}/entities`),
 
-  getQueueMessages: (ns: string, queueName: string) =>
-    get<MessageInfo[]>(`/namespaces/${encodePath(ns)}/queues/${encodePath(queueName)}/messages`),
+  getQueueMessages: (ns: string, queue: string) => get<MessageInfo[]>(`${queueUrl(ns, queue)}/messages`),
 
-  getTopicMessages: (ns: string, topicName: string) =>
-    get<MessageInfo[]>(`/namespaces/${encodePath(ns)}/topics/${encodePath(topicName)}/messages`),
+  getDeadLetterMessages: (ns: string, queue: string) => get<MessageInfo[]>(`${queueUrl(ns, queue)}/deadletter`),
 
-  getDeadLetterMessages: (ns: string, queueName: string) =>
-    get<MessageInfo[]>(`/namespaces/${encodePath(ns)}/queues/${encodePath(queueName)}/deadletter`),
+  getQueueProperties: (ns: string, queue: string) => get<QueueProperties>(`${queueUrl(ns, queue)}/properties`),
 
-  getQueueProperties: (ns: string, queueName: string) =>
-    get<QueueProperties>(`/namespaces/${encodePath(ns)}/queues/${encodePath(queueName)}/properties`),
+  purgeQueue: (ns: string, queue: string) => del(`${queueUrl(ns, queue)}/messages`),
 
-  purgeQueue: (ns: string, queueName: string) =>
-    del(`/namespaces/${encodePath(ns)}/queues/${encodePath(queueName)}/messages`),
+  purgeDeadLetter: (ns: string, queue: string) => del(`${queueUrl(ns, queue)}/deadletter`),
 
-  purgeDeadLetter: (ns: string, queueName: string) =>
-    del(`/namespaces/${encodePath(ns)}/queues/${encodePath(queueName)}/deadletter`),
+  /** Newest messages across all of the topic's subscriptions. */
+  getTopicMessages: (ns: string, topic: string) => get<MessageInfo[]>(`${topicUrl(ns, topic)}/messages`),
 
   /** entityPath is the composite "topicName/subscriptions/subName" path. */
   getSubscriptionMessages: (ns: string, entityPath: string) =>
-    get<MessageInfo[]>(`/namespaces/${encodePath(ns)}/topics/${encodePath(entityPath)}/messages`),
+    get<MessageInfo[]>(`${subscriptionUrl(ns, entityPath)}/messages`),
 
   getSubscriptionDeadLetterMessages: (ns: string, entityPath: string) =>
-    get<MessageInfo[]>(`/namespaces/${encodePath(ns)}/topics/${encodePath(entityPath)}/deadletter`),
+    get<MessageInfo[]>(`${subscriptionUrl(ns, entityPath)}/deadletter`),
 
   purgeSubscriptionDeadLetter: (ns: string, entityPath: string) =>
-    del(`/namespaces/${encodePath(ns)}/topics/${encodePath(entityPath)}/deadletter`),
+    del(`${subscriptionUrl(ns, entityPath)}/deadletter`),
 }

--- a/tests/AlmostServiceBus.SdkIntegration.Tests/DashboardApiRoutingTests.cs
+++ b/tests/AlmostServiceBus.SdkIntegration.Tests/DashboardApiRoutingTests.cs
@@ -1,0 +1,123 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Azure.Messaging.ServiceBus;
+using AlmostServiceBus.TestHost;
+
+namespace AlmostServiceBus.SdkIntegration.Tests;
+
+/// <summary>
+/// The dashboard API has one route per operation. Entity names can contain slashes, so the
+/// dashboard sends them percent-encoded as a single path segment. These tests pin both halves:
+/// an encoded slashed name reaches the right entity, and a raw slashed path is simply not a route.
+/// </summary>
+public class DashboardApiRoutingTests : IAsyncLifetime
+{
+    private readonly ServiceBusEmulatorFixture _fixture = new();
+    private readonly HttpClient _http = new();
+
+    public async Task InitializeAsync() => await _fixture.StartAsync();
+    public async Task DisposeAsync()
+    {
+        _http.Dispose();
+        await _fixture.DisposeAsync();
+    }
+
+    private string Api => $"http://localhost:{_fixture.PublicPort}/api/dashboard/namespaces/{_fixture.Namespace}";
+
+    private ServiceBusClient CreateClient() => new(
+        _fixture.ConnectionString,
+        new ServiceBusClientOptions
+        {
+            TransportType = ServiceBusTransportType.AmqpTcp,
+            RetryOptions = new ServiceBusRetryOptions { MaxRetries = 0, TryTimeout = TimeSpan.FromSeconds(10) },
+        });
+
+    [Fact]
+    public async Task SlashedQueueName_IsAddressedAsOneEncodedSegment()
+    {
+        const string queueName = "orders/eu/high";
+        _fixture.GetNamespaceContext().CreateQueue(queueName);
+
+        await using var client = CreateClient();
+        var sender = client.CreateSender(queueName);
+        await sender.SendMessageAsync(new ServiceBusMessage("body") { MessageId = "m1" });
+
+        var encoded = Uri.EscapeDataString(queueName);
+        var messages = await _http.GetFromJsonAsync<JsonElement>($"{Api}/queues/{encoded}/messages");
+        Assert.Equal("m1", messages.EnumerateArray().Single().GetProperty("messageId").GetString());
+
+        var properties = await _http.GetFromJsonAsync<JsonElement>($"{Api}/queues/{encoded}/properties");
+        Assert.Equal(queueName, properties.GetProperty("name").GetString());
+
+        // The raw slashed path is three segments and matches no route.
+        var raw = await _http.GetAsync($"{Api}/queues/{queueName}/messages");
+        Assert.Equal(HttpStatusCode.NotFound, raw.StatusCode);
+
+        // Purge, then nothing is left to receive.
+        var purge = await _http.DeleteAsync($"{Api}/queues/{encoded}/messages");
+        Assert.Equal(HttpStatusCode.OK, purge.StatusCode);
+        var after = await _http.GetFromJsonAsync<JsonElement>($"{Api}/queues/{encoded}/messages");
+        // Peek lists recently settled messages too, so check that nothing is still active.
+        Assert.DoesNotContain(after.EnumerateArray(), m => m.GetProperty("state").GetString() == "Active");
+    }
+
+    [Fact]
+    public async Task SubscriptionRoutes_ResolveTopicAndSubscriptionSegments()
+    {
+        const string topicName = "events/orders";
+        const string subscriptionName = "billing";
+        _fixture.GetNamespaceContext().CreateSubscription(topicName, subscriptionName);
+
+        await using var client = CreateClient();
+        var sender = client.CreateSender(topicName);
+        await sender.SendMessageAsync(new ServiceBusMessage("evt") { MessageId = "e1" });
+
+        var topic = Uri.EscapeDataString(topicName);
+        var subscription = $"{Api}/topics/{topic}/subscriptions/{subscriptionName}";
+
+        var live = await _http.GetFromJsonAsync<JsonElement>($"{subscription}/messages");
+        Assert.Equal("e1", live.EnumerateArray().Single().GetProperty("messageId").GetString());
+
+        // The topic view aggregates its subscriptions.
+        var aggregated = await _http.GetFromJsonAsync<JsonElement>($"{Api}/topics/{topic}/messages");
+        Assert.Single(aggregated.EnumerateArray());
+
+        var receiver = client.CreateReceiver(topicName, subscriptionName);
+        var received = await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(5));
+        Assert.NotNull(received);
+        await receiver.DeadLetterMessageAsync(received, "Rejected", "test");
+
+        var dlq = await _http.GetFromJsonAsync<JsonElement>($"{subscription}/deadletter");
+        var dead = dlq.EnumerateArray().Single();
+        Assert.Equal("e1", dead.GetProperty("messageId").GetString());
+        Assert.Equal("Rejected", dead.GetProperty("deadLetterReason").GetString());
+
+        Assert.Equal(HttpStatusCode.OK, (await _http.DeleteAsync($"{subscription}/deadletter")).StatusCode);
+        var remaining = await _http.GetFromJsonAsync<JsonElement>($"{subscription}/deadletter");
+        Assert.DoesNotContain(remaining.EnumerateArray(), m => m.GetProperty("state").GetString() == "Active");
+    }
+
+    [Fact]
+    public async Task UnknownNamespaceEntityOrSubscription_Is404()
+    {
+        _fixture.GetNamespaceContext().CreateQueue("exists");
+        _fixture.GetNamespaceContext().CreateSubscription("topic", "sub");
+
+        var cases = new[]
+        {
+            $"http://localhost:{_fixture.PublicPort}/api/dashboard/namespaces/no-such-ns/queues/exists/messages",
+            $"{Api}/queues/missing/messages",
+            $"{Api}/queues/missing/deadletter",
+            $"{Api}/queues/missing/properties",
+            $"{Api}/topics/missing/messages",
+            $"{Api}/topics/topic/subscriptions/missing/messages",
+            $"{Api}/topics/topic/subscriptions/missing/deadletter",
+        };
+
+        foreach (var url in cases)
+        {
+            Assert.Equal(HttpStatusCode.NotFound, (await _http.GetAsync(url)).StatusCode);
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #114 (which is stacked on #112). Merge those first; GitHub retargets this to `main` when #114 lands.

## Why

`DashboardApiEndpoints` had four `{**path}` catch-all routes that inspected the tail of the path (`/messages`, `/deadletter`, `/properties`), split `topic/subscriptions/sub` by hand, and repeated the namespace lookup and 404 handling in every branch.

## What

Each operation is its own route, built from nested route groups:

```
GET|DELETE /namespaces/{ns}/queues/{queue}/messages
GET|DELETE /namespaces/{ns}/queues/{queue}/deadletter
GET        /namespaces/{ns}/queues/{queue}/properties
GET        /namespaces/{ns}/topics/{topic}/messages
GET|DELETE /namespaces/{ns}/topics/{topic}/subscriptions/{subscription}/messages
GET|DELETE /namespaces/{ns}/topics/{topic}/subscriptions/{subscription}/deadletter
```

- Handlers return `TypedResults` (`Results<Ok<T>, NotFound>`), with shared `Peek`/`Purge` helpers replacing the copy-pasted branches.
- **Slashed entity names** (MassTransit and Wolverine produce them) were the reason for the catch-all. They now travel percent-encoded as one path segment. Kestrel leaves `%2F` encoded and routing passes it through, so an `EntityName` route-parameter type decodes it in exactly one place. Service Bus names cannot contain `%`, so this is unambiguous.
- The Vue client uses `encodeURIComponent` for names and splits the composite `topic/subscriptions/sub` path into two segments.
- **Purge was broken**: `DELETE .../messages` only locked the messages, which reappeared with a higher delivery count once the lock expired. It now completes them. (Nothing in the UI calls purge today, which is why nobody noticed.)

## Tests

- New `DashboardApiRoutingTests`: an encoded slashed queue name resolves for messages/properties/purge; the raw slashed path is not a route; subscription messages, aggregated topic view, subscription DLQ and DLQ purge; 404s for unknown namespace/queue/topic/subscription.
- Existing `DeadLetterVisibilityTests` unchanged and green.
- Unit 238/238, SDK integration 55/55. Manually verified against a running emulator, including a queue literally named `eu/orders/high`.

CHANGELOG has Changed + Fixed entries under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
